### PR TITLE
Add AGENTS.md with CI agent guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,57 @@
+# AGENTS.md (CI agents)
+
+This file provides contributor guidance for CI agents working in this repository.
+
+## General expectations (repo-wide)
+- Follow best Haskell practices: clear, total functions where feasible, explicit types for exported functions, and small, well-named helpers.
+- Keep changes minimal and focused.
+- For any user-facing change or CLI/API behavior change, update **README.md** and **CHANGELOG.md**.
+- Never commit secrets. Use environment variables or `.env` files (see `.env.example`) and keep credentials out of logs.
+
+## Required checks before PR
+- Ensure the code compiles:
+  - `cd haskell`
+  - `cabal build`
+
+## Recommended tools
+- **Formatting:** prefer `fourmolu` (or `ormolu` if `fourmolu` is unavailable).
+  - Example: `fourmolu -i $(rg --files -g '*.hs')`
+- **Linting:** `hlint`.
+  - Example: `hlint haskell/app haskell/test`
+- **Testing:** `cabal test`
+
+Avoid mixing formatters (e.g., do not run `stylish-haskell` alongside `ormolu/fourmolu`).
+
+## Directory-specific guidance
+
+### `haskell/`
+- Build/run/test from this directory:
+  - `cabal build`
+  - `cabal run trader-hs -- --version`
+  - `cabal test`
+- Keep new modules organized by feature (e.g., predictors in `app/Trader/Predictors.hs`).
+- When adding new CLI flags, update the README usage section and ensure JSON output remains stable.
+
+### `deploy/` and `deploy-aws-*`
+- Treat deployment scripts as sensitive; avoid embedding secrets and document required environment variables.
+
+## Environment setup
+- Install GHC and Cabal via **ghcup** (recommended).
+- From the repo root:
+  - `cd haskell`
+  - `cabal update`
+  - `cabal build`
+- Copy `.env.example` to `.env` for local secrets as needed.
+
+## CI/CD notes (suggested)
+- CI should run `cabal build` and `cabal test`.
+- Any deployment scripts should assume credentials are injected via environment variables (never committed).
+
+## Gotchas & tips
+- Most commands must be run from the `haskell/` directory (paths in README assume this).
+- Binance credentials must be set via `BINANCE_API_KEY` / `BINANCE_API_SECRET` and should never be logged.
+
+## Templates (examples)
+- Build: `cd haskell && cabal build`
+- Test: `cd haskell && cabal test`
+- Run: `cd haskell && cabal run trader-hs -- --data ../data/sample_prices.csv --price-column close`


### PR DESCRIPTION
### Motivation
- Provide CI agents with clear, machine-actionable guidance for working in this repository.
- Capture repository- and directory-specific expectations for the Haskell app under `haskell/`.
- Document required compile checks, recommended tooling, and environment variable handling for deployments.
- Reduce accidental leakage of secrets and ensure documentation updates accompany user-facing changes.

### Description
- Add a new `AGENTS.md` file that targets CI agents and outlines general expectations and Haskell best practices.
- Document required pre-PR checks including the compile step (`cd haskell` and `cabal build`) and suggested commands for run/test (`cabal run`, `cabal test`).
- Recommend tooling: `fourmolu`/`ormolu` for formatting, `hlint` for linting, and `cabal` for build/test, plus templates and directory-specific notes for `haskell/` and `deploy/`.
- Include environment setup tips (`ghcup`, `cabal update`) and CI/CD notes advising secrets via environment variables and not to commit credentials.

### Testing
- Attempted `cabal build` in the `haskell/` directory, but `cabal` was not available in the execution environment, so the build step failed. 
- No other automated tests were executed in this environment due to missing `cabal` tooling. 
- The new `AGENTS.md` itself is a documentation addition and does not change runtime code paths. 
- Recommend CI run `cd haskell && cabal build && cabal test` to validate changes in a properly provisioned environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6946fe418038832b813df69982c5f10e)