### PR TITLE
web: forward tenant key from FormData payloads

### DIFF
--- a/haskell/web/src/lib/api.ts
+++ b/haskell/web/src/lib/api.ts
@@ -178,6 +178,10 @@ function tenantKeyFromBody(body: BodyInit | null | undefined): string | null {
   if (typeof URLSearchParams !== "undefined" && body instanceof URLSearchParams) {
     return normalizeTenantKeyValue(body.get("tenantKey"));
   }
+  if (typeof FormData !== "undefined" && body instanceof FormData) {
+    const tenantKey = body.get("tenantKey");
+    return typeof tenantKey === "string" ? normalizeTenantKeyValue(tenantKey) : null;
+  }
   return null;
 }
 


### PR DESCRIPTION
### Motivation
- Allow the web API client to auto-forward tenant keys when requests use `FormData` bodies so `X-Tenant-Key` is populated for multipart/form-style requests in addition to JSON and query params.

### Description
- Add `FormData` handling to `tenantKeyFromBody` in `haskell/web/src/lib/api.ts` so the client reads `tenantKey` from `FormData` and returns it when it's a string, preserving existing behavior of not overriding an explicit header and ignoring non-string values.

### Testing
- Ran `cd haskell/web && npm test` and all web tests passed (`43` tests, `0` failures). 
- Attempted `cd haskell && cabal build` but it could not be executed in this environment because `cabal` is not installed (no build attempted).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a65cda9bd4832b88310c436864788e)