### PR TITLE
Add formal combo-aware close-timing model and policy scaffold

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 All notable changes to this project will be documented in this file.
 
 ## Unreleased
+- Formal methods: add combo-aware close-timing optimization primitives (`tm` argmax over `[ta, ta + 2*(tc-ta)]`), robust per-combo `tm` distribution stats (median/MAD/IQR), and a risk-budgeted close-decision policy scaffold for integrating timing guidance into position exits.
 - Optimizer/top-combos merge: preserve arbitrary combo/payload `source` labels when normalizing imported top-json inputs, so same-parameter combos from different source files stay distinct instead of collapsing during `merge-top-combos`.
 - CLI/API: harden wrapped Binance key-check error parsing for normal HTTP status-line prefixes (`HTTP/1.1 401`, `HTTP/2 429`) and long JSON error bodies, so auth/trade-test classification keeps the real HTTP/code/message instead of falling back to truncated wrapper text.
 - Optimizer/top-combos merge: treat JSONL `ok` as a real boolean-like success flag (`true`/`1`/`yes`), so records like `"ok":"false"` are skipped instead of being imported accidentally.

--- a/FORMAL_METHODS.md
+++ b/FORMAL_METHODS.md
@@ -62,3 +62,32 @@ It proves that the repo's stated ROI contract, as encoded in the optimizer, matc
 cd haskell
 cabal test
 ```
+
+## Formal close-timing model (combo-aware)
+
+For each position with open time `ta` and realized close time `tc`, we define an optimization window:
+
+- `tm ∈ [ta, ta + 2*(tc-ta)]`
+
+`tm` is selected as the timestamp that maximizes path PnL inside that window.
+
+We then normalize by realized duration:
+
+- `r = (tm-ta)/(tc-ta)`, so `r ∈ [0,2]`
+
+Per combo, we estimate robust distribution statistics over `r`:
+
+- median (`Q50`) as center
+- MAD (`median |r-Q50|`) as robust dispersion
+- interquartile band (`Q25`, `Q75`) as a policy interval
+
+A risk-budgeted close policy is encoded as a convex blend target:
+
+- `target = (1-β)*Q50 + β*Q75`, with `β ∈ [0,1]`
+
+A live position is marked close-ready when its age ratio exceeds `target`.
+
+### Implementation pointers
+
+- Model + policy: `haskell/app/Trader/Formal/CloseTiming.hs`
+- Unit tests: `haskell/test/TestMain.hs`

--- a/haskell/app/Trader/Formal/CloseTiming.hs
+++ b/haskell/app/Trader/Formal/CloseTiming.hs
@@ -1,0 +1,120 @@
+module Trader.Formal.CloseTiming (
+    CloseTimingDecision (..),
+    CloseTimingObservation (..),
+    CloseTimingStats (..),
+    buildCloseTimingStats,
+    closeTimingDecision,
+    optimalCloseObservation,
+) where
+
+import Data.Function (on)
+import Data.List (groupBy, sortOn)
+
+-- | Historical position sample grouped by combo.
+data CloseTimingObservation = CloseTimingObservation
+    { ctoCombo :: !String
+    , ctoOpenAtMs :: !Int
+    , ctoCloseAtMs :: !Int
+    , ctoOptimalCloseAtMs :: !Int
+    }
+    deriving (Eq, Show)
+
+-- | Robust summary over tm in normalized units:
+--   r = (tm - ta) / (tc - ta), with support [0, 2].
+data CloseTimingStats = CloseTimingStats
+    { ctsCombo :: !String
+    , ctsSamples :: !Int
+    , ctsMedianRatio :: !Double
+    , ctsMadRatio :: !Double
+    , ctsQ25Ratio :: !Double
+    , ctsQ75Ratio :: !Double
+    }
+    deriving (Eq, Show)
+
+-- | Close policy: recommend hold if age ratio is below the risk-budget quantile.
+data CloseTimingDecision = CloseTimingDecision
+    { ctdShouldClose :: !Bool
+    , ctdAgeRatio :: !Double
+    , ctdTargetRatio :: !Double
+    }
+    deriving (Eq, Show)
+
+optimalCloseObservation :: String -> Int -> Int -> [(Int, Double)] -> Maybe CloseTimingObservation
+optimalCloseObservation combo ta tc pnlPath
+    | tc <= ta = Nothing
+    | null candidates = Nothing
+    | otherwise =
+        let (tm, _) =
+                foldl1
+                    (\best cur -> if snd cur > snd best then cur else best)
+                    candidates
+         in Just
+                CloseTimingObservation
+                    { ctoCombo = combo
+                    , ctoOpenAtMs = ta
+                    , ctoCloseAtMs = tc
+                    , ctoOptimalCloseAtMs = tm
+                    }
+  where
+    upper = ta + 2 * (tc - ta)
+    candidates = filter (\(t, pnl) -> t >= ta && t <= upper && isFinite pnl) pnlPath
+
+buildCloseTimingStats :: [CloseTimingObservation] -> [CloseTimingStats]
+buildCloseTimingStats obs =
+    map statsFor grouped
+  where
+    grouped =
+        groupBy ((==) `on` ctoCombo) . sortOn ctoCombo $ filter valid obs
+
+    valid x =
+        let denom = ctoCloseAtMs x - ctoOpenAtMs x
+            num = ctoOptimalCloseAtMs x - ctoOpenAtMs x
+         in denom > 0 && num >= 0 && num <= 2 * denom
+
+    statsFor xs =
+        let combo = ctoCombo (head xs)
+            ratios = sortOn id (map ratio xs)
+            med = percentile 0.5 ratios
+            mad = percentile 0.5 (sortOn id (map (abs . subtract med) ratios))
+         in CloseTimingStats
+                { ctsCombo = combo
+                , ctsSamples = length ratios
+                , ctsMedianRatio = med
+                , ctsMadRatio = mad
+                , ctsQ25Ratio = percentile 0.25 ratios
+                , ctsQ75Ratio = percentile 0.75 ratios
+                }
+
+    ratio x =
+        let denom = fromIntegral (ctoCloseAtMs x - ctoOpenAtMs x)
+            num = fromIntegral (ctoOptimalCloseAtMs x - ctoOpenAtMs x)
+         in clamp 0 2 (num / denom)
+
+closeTimingDecision :: Double -> CloseTimingStats -> Int -> Int -> Int -> CloseTimingDecision
+closeTimingDecision riskBudget stats ta expectedDurationMs now =
+    let denom = max 1 expectedDurationMs
+        age = max 0 (now - ta)
+        ageRatio = fromIntegral age / fromIntegral denom
+        target = mix (clamp 0 1 riskBudget) (ctsMedianRatio stats) (ctsQ75Ratio stats)
+     in CloseTimingDecision
+            { ctdShouldClose = ageRatio >= target
+            , ctdAgeRatio = ageRatio
+            , ctdTargetRatio = target
+            }
+
+mix :: Double -> Double -> Double -> Double
+mix w a b = (1 - w) * a + w * b
+
+percentile :: Double -> [Double] -> Double
+percentile _ [] = 1
+percentile p xs =
+    let ys = sortOn id xs
+        n = length ys
+        idx = floor (clamp 0 1 p * fromIntegral (n - 1))
+     in ys !! idx
+
+clamp :: Double -> Double -> Double -> Double
+clamp lo hi = max lo . min hi
+
+isFinite :: Double -> Bool
+isFinite x = not (isNaN x || isInfinite x)

--- a/haskell/test/TestMain.hs
+++ b/haskell/test/TestMain.hs
@@ -49,6 +49,14 @@ import Trader.Coinbase (CoinbaseCandle (..), buildRanges, decodeCoinbaseCandles,
 import Trader.Config (shouldRequireUserTradeKeys, validateRuntimeConfig)
 import Trader.Dex (DexEnv (..), DexToken (..), extractTxHash, resolveDexTokens, tokenAmountToInteger)
 import Trader.Duration (TimeWindow (..), inferPeriodsPerYear, lookbackBarsFrom, minuteOfDayFromMs, parseDurationSeconds, parseTimeWindow)
+import Trader.Formal.CloseTiming (
+    CloseTimingDecision (..),
+    CloseTimingObservation (..),
+    CloseTimingStats (..),
+    buildCloseTimingStats,
+    closeTimingDecision,
+    optimalCloseObservation,
+ )
 import Trader.Formal.Optimization (
     FormalVerificationReport (..),
     roiRequirementClauses,
@@ -163,6 +171,8 @@ main = do
               , run "formal ROI monotonicity holds" testFormalRoiMonotonicity
               , run "formal ROI penalties stay ordered" testFormalRoiPenaltyOrdering
               , run "formal tune tie-break matches spec" testFormalTieBreakMatchesSpec
+              , run "formal close timing window identifies tm" testFormalCloseTimingWindow
+              , run "formal close timing policy closes past target quantile" testFormalCloseTimingDecision
               , run "binance signature length" testBinanceSignatureLength
               , run "binance kline json parsing" testBinanceKlineParsing
               , run "binance trade parser accepts numeric and whitespace fields" testBinanceTradeParserAcceptsNumericAndWhitespace
@@ -3098,6 +3108,47 @@ testOptimizerIntRangeFullSpan = do
     assert "full-span sample stays in bounds (first)" (v1 >= minBound && v1 <= maxBound)
     assert "full-span sample stays in bounds (second)" (v2 >= minBound && v2 <= maxBound)
     assert "full-span range advances RNG state" (probe /= expectedProbe)
+
+
+
+testFormalCloseTimingWindow :: IO ()
+testFormalCloseTimingWindow = do
+    let sample =
+            optimalCloseObservation
+                "combo-a"
+                1000
+                2000
+                [ (900, -1)
+                , (1200, 0.1)
+                , (1500, 0.4)
+                , (2600, 0.7)
+                , (2900, 0.6)
+                ]
+    case sample of
+        Nothing -> error "expected optimal close sample"
+        Just obs -> do
+            assert "tm stays within [ta, 2tc-ta]" (ctoOptimalCloseAtMs obs == 2600)
+            let stats = buildCloseTimingStats [obs]
+            assert "one combo stat emitted" (length stats == 1)
+            case stats of
+                [st] -> assert "single-sample median ratio is 1.6" (abs (ctsMedianRatio st - 1.6) < 1e-9)
+                _ -> pure ()
+
+testFormalCloseTimingDecision :: IO ()
+testFormalCloseTimingDecision = do
+    let observations =
+            [ CloseTimingObservation "combo-a" 0 100 120
+            , CloseTimingObservation "combo-a" 0 100 140
+            , CloseTimingObservation "combo-a" 0 100 160
+            ]
+        stats = buildCloseTimingStats observations
+    case stats of
+        [st] -> do
+            let holdDecision = closeTimingDecision 0.0 st 0 100 120
+                closeDecision = closeTimingDecision 1.0 st 0 100 180
+            assert "policy holds before target quantile" (not (ctdShouldClose holdDecision))
+            assert "policy closes after risk-budget target" (ctdShouldClose closeDecision)
+        _ -> error "expected one combo stat"
 
 formalVerificationReport :: FormalVerificationReport
 formalVerificationReport = verifyFormalOptimization

--- a/haskell/trader.cabal
+++ b/haskell/trader.cabal
@@ -23,6 +23,7 @@ executable trader-hs
                      , Trader.BinanceIntervals
                      , Trader.BotStartSemantics
                      , Trader.Duration
+                     , Trader.Formal.CloseTiming
                      , Trader.Formal.Optimization
                      , Trader.Http
                      , Trader.KalmanFusion
@@ -178,6 +179,7 @@ test-suite trader-tests
                      , Trader.BinanceIntervals
                      , Trader.BotStartSemantics
                      , Trader.Duration
+                     , Trader.Formal.CloseTiming
                      , Trader.Formal.Optimization
                      , Trader.Http
                      , Trader.KalmanFusion
@@ -254,6 +256,7 @@ benchmark trader-bench
                      , Trader.App.Args
                      , Trader.BinanceIntervals
                      , Trader.Duration
+                     , Trader.Formal.CloseTiming
                      , Trader.Formal.Optimization
                      , Trader.Http
                      , Trader.KalmanFusion


### PR DESCRIPTION
### Motivation
- Formalize and automate analysis of when positions (historical and live) would have achieved maximum PnL inside a bounded search window, grouped by combo, to inform an evidence-based close-timing policy. 
- Provide robust, combo-level statistics over normalized optimal-close times and expose a risk-budgeted decision rule that can be integrated into position-exit logic and optimizer/formal-methods workflows.

### Description
- Add a new module `Trader.Formal.CloseTiming` implementing `CloseTimingObservation`, `CloseTimingStats`, `CloseTimingDecision`, `optimalCloseObservation`, `buildCloseTimingStats`, and `closeTimingDecision` which: finds `tm = argmax PnL` on the window `tm ∈ [ta, ta + 2*(tc-ta)]`, normalizes `r = (tm-ta)/(tc-ta) ∈ [0,2]`, and computes robust statistics (`Q50`, `MAD`, `Q25`, `Q75`) and a convex blend policy target `target = (1-β)*Q50 + β*Q75`.
- Wire the new module into the Cabal component lists so it is available to the main executable, test-suite, and benchmark via `haskell/trader.cabal` updates.
- Add unit tests to `haskell/test/TestMain.hs` that validate optimal `tm` extraction within the bounded window and the risk-budgeted decision behavior for a simple combo sample.
- Document the model and policy in `FORMAL_METHODS.md` and record the change under `Unreleased` in `CHANGELOG.md`.

### Testing
- Ran `git diff --check` in the repo and it completed successfully. 
- Attempted to run `cabal build` from `haskell/`, but the Haskell toolchain is not available in this environment so the build/test step could not be executed (no `cabal`/`ghc` found). 
- The new unit tests were added to the test suite (`haskell/test/TestMain.hs`) but were not executed here due to the unavailable toolchain.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69acff7a71b0832bbc2d493c5cf801ea)