### PR TITLE
Add bounded chart downsampling invariants to web utils tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 All notable changes to this project will be documented in this file.
 
 ## Unreleased
+- Predictors/Backtests/CLI: add OHLCV-aware feature engineering (candle body/range/wick, ATR/breakout, volume shock, efficiency, plus market-context residual features) and new `knn` / `decision_tree` predictors wired through the existing `--predictors` Kalman/backtest/trade-only flow, so optimizer and backtest runs can learn from richer Kline context around entry/hold/exit decisions.
 - Dev/CI: add a repo-local persistent autoloop supervisor (`scripts/autoloop-forever.sh` + `scripts/autoloop-forever.mjs`) that sources repo `.env` at launch, stores PID/status/logs under `.tmp/autoloop/`, honors stop files/signals, auto-selects OpenAI or Codex planning backends, pauses on dirty worktrees or missing backends, and keeps re-running the bounded autoloop without busy looping.
 - Dev/CI: require each bounded autoloop cycle to record explicit change-selection, UI/UX review, and correctness/formal-review phases, including named web/test/formal review targets plus summary metadata in the cycle status JSON.
 - Dev/CI: add a scheduled/manual `Autoloop` GitHub Actions workflow that runs one bounded autonomous improvement cycle at a time, opens or refreshes an `autoloop/<default-branch>` PR, waits for the normal `CI` workflow, auto-merges on green, and constrains model output with explicit path/command guardrails plus planned-path-only staging.

--- a/README.md
+++ b/README.md
@@ -11,16 +11,18 @@ Features
 - Multi-sensor Kalman fusion filter for latent expected return (`haskell/app/Trader/KalmanFusion.hs`).
 - Multiple predictive methods feeding into Kalman as an observation vector (`haskell/app/Trader/Predictors.hs`):
   - Gradient-boosted trees (LightGBM/CatBoost style, simplified)
+  - Distance-weighted k-nearest neighbors regression
+  - Decision-tree regression
   - TCN / dilated 1D CNN (simplified)
   - Transformer-style attention predictor (kNN attention)
   - HMM / regime model (3 regimes)
   - Quantile regression (q10/q50/q90)
 - Conformal interval wrapper (calibrated on a holdout split, sigma derived from alpha; omitted when calibration is empty)
 - Predictor training validates fixed feature dimensions to avoid silent mismatches.
-- Predictor outputs omit transformer/GBDT/quantile/conformal when the feature dataset is empty or features do not match the trained dimensions.
+- Feature-based predictor outputs omit GBDT/kNN/decision-tree/transformer/quantile/conformal when the feature dataset is empty or features do not match the trained dimensions.
 - Quantile outputs clamp the reported median inside the q10/q90 bounds and omit sigma when the interval is invalid; the sensor mean uses the clamped median.
 - Predictor training uses a train/calibration split so held-out calibration data is excluded from model training.
-- Feature engineering includes psychological round-number proximity (big figures/halves/quarters/tenths), short/mid momentum and volatility spread features, and market-context residual/correlation features when Binance market context is available.
+- Feature engineering includes per-bar OHLCV context (body/range/wick, gap, ATR/breakout, volume shock, efficiency), psychological round-number proximity, short/mid momentum and volatility spread features, and market-context residual/correlation features when Binance market context is available.
 - LSTM next-step predictor with Adam, gradient clipping, and early stopping (`haskell/app/Trader/LSTM.hs`).
 - Agreement-gated ensemble strategy (`haskell/app/Trader/Trading.hs`).
 - Context-aware blend/pick methods guard against non-finite model outputs (`NaN`/`Infinity`) by falling back to a neutral finite prediction (current price when available).
@@ -316,8 +318,9 @@ You must provide exactly one data source: `--data` (CSV) or `--symbol`/`--binanc
   - `--kalman-process-var 1e-5` process noise variance
   - `--kalman-measurement-var 1e-3` fallback measurement variance (and initial variance)
   - `--kalman-market-top-n 50` optional market context measurement; skipped if fewer than `min(N, 5)` symbols are available
-  - `--predictors gbdt,tcn,transformer,hmm,quantile,conformal` comma-separated predictors to train/use (`all`/`none` accepted; default is all; `all` and `none` cannot be combined)
+  - `--predictors gbdt,knn,decision_tree,tcn,transformer,hmm,quantile,conformal` comma-separated predictors to train/use (`all`/`none` accepted; default is all; `all` and `none` cannot be combined)
     - Conformal intervals use the GBDT model internally, even if `gbdt` isn't selected as a sensor.
+    - kNN / decision-tree predictors use the same OHLCV + market-context feature set as the other feature-based models and are evaluated on every decision bar, including bars during open positions.
     - HMM/quantile/conformal confirmations only apply when their predictors are enabled.
     - If a predictor output is missing for a bar, its confirmation/width gates are skipped (treated as pass).
 

--- a/haskell/app/Main.hs
+++ b/haskell/app/Main.hs
@@ -190,6 +190,7 @@ import Trader.Coinbase (
     coinbaseBaseUrl,
     fetchCoinbaseAccounts,
     fetchCoinbaseAvailableBalance,
+    fetchCoinbaseBaseMinSize,
     fetchCoinbaseCandles,
     newCoinbaseEnv,
     placeCoinbaseMarketOrder,
@@ -263,11 +264,11 @@ import Trader.Predictors (
     SensorId (..),
     SensorOutput (..),
     initHMMFilter,
-    predictSensors,
-    trainPredictors,
-    trainPredictorsWithMarket,
+    predictSensorsWithInputs,
+    trainPredictorsWithInputsWithMarket,
     updateHMM,
  )
+import Trader.Predictors.Features (FeatureInputs (..), mkFeatureInputs)
 import Trader.Predictors.Types (
     predictorCode,
     predictorEnabled,
@@ -4176,8 +4177,10 @@ data BotState = BotState
     , botEnv :: !BinanceEnv
     , botLookback :: !Int
     , botPrices :: !(V.Vector Double)
+    , botOpens :: !(V.Vector Double)
     , botHighs :: !(V.Vector Double)
     , botLows :: !(V.Vector Double)
+    , botVolumes :: !(V.Vector Double)
     , botOpenTimes :: !(V.Vector Int64)
     , botKalmanPredNext :: !(V.Vector Double) -- predicted next price at each bar (len == prices)
     , botLstmPredNext :: !(V.Vector Double) -- predicted next price at each bar (len == prices)
@@ -4217,6 +4220,15 @@ data BotState = BotState
     , botLastBatchMs :: !Int
     , botError :: !(Maybe String)
     }
+
+botFeatureInputs :: BotState -> FeatureInputs
+botFeatureInputs st =
+    mkFeatureInputs
+        (botPrices st)
+        (Just (botOpens st))
+        (Just (botHighs st))
+        (Just (botLows st))
+        (Just (botVolumes st))
 
 newBotController :: IO BotController
 newBotController = BotController <$> newMVar HM.empty
@@ -4662,8 +4674,10 @@ botStateTail tailN st =
                             Just ot -> Just (shiftOpenTradeIndex dropCount ot)
                  in st
                         { botPrices = V.drop dropCount (botPrices st)
+                        , botOpens = V.drop dropCount (botOpens st)
                         , botHighs = V.drop dropCount (botHighs st)
                         , botLows = V.drop dropCount (botLows st)
+                        , botVolumes = V.drop dropCount (botVolumes st)
                         , botOpenTimes = V.drop dropCount (botOpenTimes st)
                         , botKalmanPredNext = V.drop dropCount (botKalmanPredNext st)
                         , botLstmPredNext = V.drop dropCount (botLstmPredNext st)
@@ -6342,12 +6356,17 @@ initBotState mOps tenantKey args settings mComboUuid originIp sym = do
     ks <- fetchKlines env sym (argInterval args) initBars
     when (length ks < 2) $ throwIO (userError "Not enough klines to start bot")
     let closes = map kClose ks
+        opens = map kOpen ks
         highs = map kHigh ks
         lows = map kLow ks
+        volumes = map kVolume ks
         openTimes = map kOpenTime ks
         pricesV = V.fromList closes
+        opensV = V.fromList opens
         highsV = V.fromList highs
         lowsV = V.fromList lows
+        volumesV = V.fromList volumes
+        featureInputs = mkFeatureInputs pricesV (Just opensV) (Just highsV) (Just lowsV) (Just volumesV)
         openV = V.fromList openTimes
         n = V.length pricesV
 
@@ -6410,7 +6429,7 @@ initBotState mOps tenantKey args settings mComboUuid originIp sym = do
         case methodForCtx of
             MethodLstmOnly -> pure (Nothing, V.replicate n nan)
             _ -> do
-                let predictors = trainPredictors (argPredictors args) lookback pricesV
+                let predictors = trainPredictorsWithInputsWithMarket (argPredictors args) lookback Nothing featureInputs
                     hmm0 = initHMMFilter predictors []
                     kal0 =
                         initKalman1
@@ -6423,7 +6442,7 @@ initBotState mOps tenantKey args settings mComboUuid originIp sym = do
                         let priceT = pricesV V.! t
                             nextP = pricesV V.! (t + 1)
                             realizedR = if priceT == 0 then 0 else nextP / priceT - 1
-                            (sensorOuts, predState) = predictSensors predictors pricesV hmm t
+                            (sensorOuts, predState) = predictSensorsWithInputs predictors featureInputs hmm t
                             meas = mapMaybe (toMeasurement args sv) sensorOuts
                             kal' = stepMulti meas kal
                             fusedR = kMean kal'
@@ -6439,7 +6458,7 @@ initBotState mOps tenantKey args settings mComboUuid originIp sym = do
                     (kalPrev, hmmPrev, svPrev, predsRev) = foldl' step (kal0, hmm0, sv0, []) [0 .. n - 2]
                     preds = reverse predsRev
                     lastPrice = vectorLastOr 0 pricesV
-                    (sensorOutsLast, _) = predictSensors predictors pricesV hmmPrev (n - 1)
+                    (sensorOutsLast, _) = predictSensorsWithInputs predictors featureInputs hmmPrev (n - 1)
                     measLast = mapMaybe (toMeasurement args svPrev) sensorOutsLast
                     kalLast = stepMulti measLast kalPrev
                     kalLastNext = lastPrice * (1 + kMean kalLast)
@@ -6464,9 +6483,7 @@ initBotState mOps tenantKey args settings mComboUuid originIp sym = do
         case computeLatestSignal
             args
             lookback
-            pricesV
-            (Just highsV)
-            (Just lowsV)
+            featureInputs
             mLstmCtx
             mKalmanCtx
             Nothing
@@ -6643,9 +6660,9 @@ initBotState mOps tenantKey args settings mComboUuid originIp sym = do
         maxPoints = max (lookback + 3) (bsMaxPoints settings)
         dropCount = max 0 (V.length pricesV - maxPoints)
 
-        (pricesV2, highsV2, lowsV2, openV2, kalPred2, lstmPred2, eq2, pos2, ops2, orders2, openTrade2, startIndex2, mLstmCtx2) =
+        (pricesV2, opensV2, highsV2, lowsV2, volumesV2, openV2, kalPred2, lstmPred2, eq2, pos2, ops2, orders2, openTrade2, startIndex2, mLstmCtx2) =
             if dropCount <= 0
-                then (pricesV, highsV, lowsV, openV, kalPred0, lstmPred0, eq1, pos1, ops, orders, openTrade, 0, mLstmCtx)
+                then (pricesV, opensV, highsV, lowsV, volumesV, openV, kalPred0, lstmPred0, eq1, pos1, ops, orders, openTrade, 0, mLstmCtx)
                 else
                     let openTradeShifted =
                             case openTrade of
@@ -6667,8 +6684,10 @@ initBotState mOps tenantKey args settings mComboUuid originIp sym = do
                                 Just (normState, obsAll, lstmModel) ->
                                     Just (normState, drop dropCount obsAll, lstmModel)
                      in ( V.drop dropCount pricesV
+                        , V.drop dropCount opensV
                         , V.drop dropCount highsV
                         , V.drop dropCount lowsV
+                        , V.drop dropCount volumesV
                         , V.drop dropCount openV
                         , V.drop dropCount kalPred0
                         , V.drop dropCount lstmPred0
@@ -6709,8 +6728,10 @@ initBotState mOps tenantKey args settings mComboUuid originIp sym = do
                 , botEnv = env
                 , botLookback = lookback
                 , botPrices = pricesV2
+                , botOpens = opensV2
                 , botHighs = highsV2
                 , botLows = lowsV2
+                , botVolumes = volumesV2
                 , botOpenTimes = openV2
                 , botKalmanPredNext = kalPred2
                 , botLstmPredNext = lstmPred2
@@ -6953,9 +6974,7 @@ botOptimizeAfterOperation st = do
                     case computeLatestSignal
                         argsSignal
                         lookback
-                        pricesV
-                        (Just (botHighs st))
-                        (Just (botLows st))
+                        (botFeatureInputs st)
                         (botLstmCtx st)
                         (botKalmanCtx st)
                         Nothing
@@ -7061,9 +7080,7 @@ botApplyOptimizerUpdate st upd = do
                     case computeLatestSignal
                         argsSignal
                         lookback'
-                        pricesV
-                        (Just (botHighs st))
-                        (Just (botLows st))
+                        (botFeatureInputs st)
                         mLstmCtx'
                         mKalmanCtx'
                         Nothing
@@ -7106,13 +7123,14 @@ rebuildLstmCtx args lookback pricesV =
                 (lstmModel, _) <- trainLstmWithPersistence args lookback lstmCfg obsAll
                 pure (Right (normState, obsAll, lstmModel))
 
-rebuildKalmanCtx :: Args -> Int -> V.Vector Double -> Either String KalmanCtx
-rebuildKalmanCtx args lookback pricesV =
-    let n = V.length pricesV
+rebuildKalmanCtx :: Args -> Int -> FeatureInputs -> Either String KalmanCtx
+rebuildKalmanCtx args lookback featureInputs =
+    let pricesV = fiClose featureInputs
+        n = V.length pricesV
      in if n < 2
             then Left "Not enough bars to rebuild Kalman context."
             else
-                let predictors = trainPredictors (argPredictors args) lookback pricesV
+                let predictors = trainPredictorsWithInputsWithMarket (argPredictors args) lookback Nothing featureInputs
                     hmm0 = initHMMFilter predictors []
                     kal0 =
                         initKalman1
@@ -7125,7 +7143,7 @@ rebuildKalmanCtx args lookback pricesV =
                         let priceT = pricesV V.! t
                             nextP = pricesV V.! (t + 1)
                             realizedR = if priceT == 0 then 0 else nextP / priceT - 1
-                            (sensorOuts, predState) = predictSensors predictors pricesV hmm t
+                            (sensorOuts, predState) = predictSensorsWithInputs predictors featureInputs hmm t
                             meas = mapMaybe (toMeasurement args sv) sensorOuts
                             kal' = stepMulti meas kal
                             sv' =
@@ -7458,7 +7476,7 @@ buildOptimizerUpdate st combo = do
                                 )
                         else do
                             mLstmE <- if needsLstm' then Just <$> rebuildLstmCtx args0 lookback pricesV else pure Nothing
-                            let mKalE = if needsKalman' then Just (rebuildKalmanCtx args0 lookback pricesV) else Nothing
+                            let mKalE = if needsKalman' then Just (rebuildKalmanCtx args0 lookback (botFeatureInputs st)) else Nothing
                                 collect =
                                     case (mLstmE, mKalE) of
                                         (Just (Left e), _) -> Left e
@@ -8409,9 +8427,12 @@ botApplyKline mOps metrics mJournal mWebhook topCombosCtx ctrl st k = do
         halted = isJust haltReason1
 
         pricesV = V.snoc pricesPrev priceNew
+        opensV = V.snoc (botOpens st) (kOpen k)
         highsV = V.snoc (botHighs st) (kHigh k)
         lowsV = V.snoc (botLows st) (kLow k)
+        volumesV = V.snoc (botVolumes st) (kVolume k)
         openTimesV = V.snoc (botOpenTimes st) openTimeNew
+        featureInputs = mkFeatureInputs pricesV (Just opensV) (Just highsV) (Just lowsV) (Just volumesV)
 
     -- Update Kalman/HMM/sensor variance with the realized return on the last step.
     mKalmanCtx1 <-
@@ -8420,7 +8441,7 @@ botApplyKline mOps metrics mJournal mWebhook topCombosCtx ctrl st k = do
             Just (predictors, kalPrev, hmmPrev, svPrev) -> do
                 let t = nPrev - 1
                     realizedR = if prevPrice == 0 then 0 else priceNew / prevPrice - 1
-                    (sensorOuts, predState) = predictSensors predictors pricesV hmmPrev t
+                    (sensorOuts, predState) = predictSensorsWithInputs predictors featureInputs hmmPrev t
                     meas = mapMaybe (toMeasurement args svPrev) sensorOuts
                     kal' = stepMulti meas kalPrev
                     sv' =
@@ -8465,9 +8486,7 @@ botApplyKline mOps metrics mJournal mWebhook topCombosCtx ctrl st k = do
         case computeLatestSignal
             argsSignal
             lookback
-            pricesV
-            (Just highsV)
-            (Just lowsV)
+            featureInputs
             mLstmCtx1
             mKalmanCtx1
             Nothing
@@ -9278,9 +9297,9 @@ botApplyKline mOps metrics mJournal mWebhook topCombosCtx ctrl st k = do
         maxPoints = max (lookback + 3) (bsMaxPoints settings)
         dropCount = max 0 (V.length pricesV - maxPoints)
 
-        (pricesV2, highsV2, lowsV2, openTimesV2, kalPred2, lstmPred2, eqV2, posV2, ops2, orders2, trades2, openTrade2, startIndex2) =
+        (pricesV2, opensV2, highsV2, lowsV2, volumesV2, openTimesV2, kalPred2, lstmPred2, eqV2, posV2, ops2, orders2, trades2, openTrade2, startIndex2) =
             if dropCount <= 0
-                then (pricesV, highsV, lowsV, openTimesV, kalPred1, lstmPred1, eqV1, posV1, ops', orders', trades', openTrade', botStartIndex st)
+                then (pricesV, opensV, highsV, lowsV, volumesV, openTimesV, kalPred1, lstmPred1, eqV1, posV1, ops', orders', trades', openTrade', botStartIndex st)
                 else
                     let shiftTrade tr =
                             tr{trEntryIndex = trEntryIndex tr - dropCount, trExitIndex = trExitIndex tr - dropCount}
@@ -9305,8 +9324,10 @@ botApplyKline mOps metrics mJournal mWebhook topCombosCtx ctrl st k = do
                             , boeIndex e >= dropCount
                             ]
                      in ( V.drop dropCount pricesV
+                        , V.drop dropCount opensV
                         , V.drop dropCount highsV
                         , V.drop dropCount lowsV
+                        , V.drop dropCount volumesV
                         , V.drop dropCount openTimesV
                         , V.drop dropCount kalPred1
                         , V.drop dropCount lstmPred1
@@ -9330,8 +9351,10 @@ botApplyKline mOps metrics mJournal mWebhook topCombosCtx ctrl st k = do
     let st1 =
             st
                 { botPrices = pricesV2
+                , botOpens = opensV2
                 , botHighs = highsV2
                 , botLows = lowsV2
+                , botVolumes = volumesV2
                 , botOpenTimes = openTimesV2
                 , botKalmanPredNext = kalPred2
                 , botLstmPredNext = lstmPred2
@@ -19265,12 +19288,15 @@ placeCoinbaseOrderForSignal args symRaw sig env = do
                             else do
                                 baseBal <- fetchCoinbaseAvailableBalance env baseAsset
                                 quoteBal <- fetchCoinbaseAvailableBalance env quoteAsset
+                                mBaseMinQty <- do
+                                    r <- try (fetchCoinbaseBaseMinSize env sym) :: IO (Either SomeException (Maybe Double))
+                                    pure (either (const Nothing) id r)
                                 case chosenDir of
                                     Nothing -> noOrder neutralMsg
                                     Just dir ->
                                         case dir of
-                                            1 -> placeBuy baseBal quoteBal baseAsset quoteAsset
-                                            (-1) -> placeSell baseBal baseAsset
+                                            1 -> placeBuy baseBal quoteBal mBaseMinQty baseAsset quoteAsset
+                                            (-1) -> placeSell baseBal mBaseMinQty baseAsset
                                             _ -> noOrder neutralMsg
   where
     sym = normalizeSymbol symRaw
@@ -19280,6 +19306,10 @@ placeCoinbaseOrderForSignal args symRaw sig env = do
 
     entryScale :: Double
     entryScale = entryScaleForSignal args MarketSpot sig
+
+    exitScale :: Double
+    exitScale =
+        maybe 1 clamp01 (lsExitSize sig)
 
     clientOrderId :: Maybe String
     clientOrderId = trim <$> argIdempotencyKey args
@@ -19344,6 +19374,12 @@ placeCoinbaseOrderForSignal args symRaw sig env = do
     lstmBlockMsg :: Maybe String
     lstmBlockMsg = snd (lstmConfidenceSizing args sig)
 
+    isLongCoinbaseSpot :: Maybe Double -> Double -> Bool
+    isLongCoinbaseSpot mMinQty baseBal =
+        case mMinQty of
+            Just minQty | minQty > 0 -> baseBal >= minQty
+            _ -> baseBal > 0
+
     splitCoinbaseSymbol s =
         case break (== '-') s of
             (base, '-' : quote)
@@ -19370,8 +19406,8 @@ placeCoinbaseOrderForSignal args symRaw sig env = do
                         , aorMessage = "Order sent."
                         }
 
-    placeBuy baseBal quoteBal _baseAsset quoteAsset =
-        if baseBal > 0
+    placeBuy baseBal quoteBal mBaseMinQty _baseAsset quoteAsset =
+        if isLongCoinbaseSpot mBaseMinQty baseBal
             then noOrder "No order: already long."
             else case lstmBlockMsg of
                 Just msg -> noOrder msg
@@ -19419,8 +19455,8 @@ placeCoinbaseOrderForSignal args symRaw sig env = do
                                             then noOrder ("No order: insufficient " ++ quoteAsset ++ " balance.")
                                             else sendOrder "BUY" Nothing (Just qq)
 
-    placeSell baseBal _baseAsset =
-        if baseBal <= 0
+    placeSell baseBal mBaseMinQty _baseAsset =
+        if not (isLongCoinbaseSpot mBaseMinQty baseBal)
             then noOrder "No order: already flat."
             else do
                 let qtyArg =
@@ -19428,13 +19464,22 @@ placeCoinbaseOrderForSignal args symRaw sig env = do
                             Just q | q > 0 -> Just q
                             _ -> Nothing
                     qtyArgSell = qtyArg
-                    qRaw =
+                    qRaw0 =
                         case qtyArgSell of
                             Just q -> min q baseBal
                             Nothing -> baseBal
-                if qRaw <= 0
-                    then noOrder "No order: quantity is 0."
-                    else sendOrder "SELL" (Just qRaw) Nothing
+                    qRaw = qRaw0 * exitScale
+                case mBaseMinQty of
+                    Just minQty | baseBal < minQty -> noOrder "No order: position below exchange minimums (dust)."
+                    Just minQty | qRaw > 0 && qRaw < minQty ->
+                        noOrder $
+                            if isJust qtyArgSell
+                                then "No order: orderQuantity below exchange minimums."
+                                else "No order: exit size below exchange minimums."
+                    _ ->
+                        if qRaw <= 0
+                            then noOrder "No order: quantity is 0."
+                            else sendOrder "SELL" (Just qRaw) Nothing
 
 computeBacktestFromArgs :: Maybe OpsStore -> Args -> IO Aeson.Value
 computeBacktestFromArgs mOps args = do
@@ -19979,10 +20024,9 @@ computeTradeOnlySignal args lookback series mBinanceEnv = do
         (throwIO (userError "Cannot use --optimize-operations with --trade-only (optimization requires a backtest split)."))
 
     let prices = psClose series
-        highsV = V.fromList <$> psHigh series
-        lowsV = V.fromList <$> psLow series
+        featureInputs = featureInputsFromSeries series
         method = runtimeMethod (argMethod args)
-        pricesV = V.fromList prices
+        pricesV = fiClose featureInputs
         n = V.length pricesV
         stepCount = max 0 (n - 1)
         needsHistory = argThresholdFactorEnabled args || method == MethodRouter || method == MethodBanditRouter
@@ -20050,7 +20094,7 @@ computeTradeOnlySignal args lookback series mBinanceEnv = do
         case method of
             MethodLstmOnly -> pure (Nothing, Nothing, Nothing)
             _ | needsHistory -> do
-                let predictors = trainPredictorsWithMarket (argPredictors args) lookback mMarketModel pricesV
+                let predictors = trainPredictorsWithInputsWithMarket (argPredictors args) lookback mMarketModel featureInputs
                     hmm0 = initHMMFilter predictors []
                     kal0 =
                         initKalman1
@@ -20060,14 +20104,14 @@ computeTradeOnlySignal args lookback series mBinanceEnv = do
                     sv0 = emptySensorVar
                     (kalPrev, hmmPrev, svPrev, kalPredRev, metaRev) =
                         foldl'
-                            (backtestStepKalmanOnly args pricesV predictors 0 mMarketModel)
+                            (backtestStepKalmanOnly args featureInputs predictors 0 mMarketModel)
                             (kal0, hmm0, sv0, [], [])
                             [0 .. stepCount - 1]
                     kalPredV = V.fromList (reverse kalPredRev)
                     metaV = V.fromList (reverse metaRev)
                 pure (Just (predictors, kalPrev, hmmPrev, svPrev), Just kalPredV, Just metaV)
             _ -> do
-                let predictors = trainPredictorsWithMarket (argPredictors args) lookback mMarketModel pricesV
+                let predictors = trainPredictorsWithInputsWithMarket (argPredictors args) lookback mMarketModel featureInputs
                     hmm0 = initHMMFilter predictors []
                     kal0 =
                         initKalman1
@@ -20080,7 +20124,7 @@ computeTradeOnlySignal args lookback series mBinanceEnv = do
                         let priceT = pricesV V.! t
                             nextP = pricesV V.! (t + 1)
                             realizedR = if priceT == 0 then 0 else nextP / priceT - 1
-                            (sensorOuts, predState) = predictSensors predictors pricesV hmm t
+                            (sensorOuts, predState) = predictSensorsWithInputs predictors featureInputs hmm t
                             meas = mapMaybe (toMeasurement args sv) sensorOuts ++ maybeToList (mMarketModel >>= (`marketMeasurementAt` t))
                             kal' = stepMulti meas kal
                             sv' =
@@ -20124,7 +20168,7 @@ computeTradeOnlySignal args lookback series mBinanceEnv = do
                                 }
                     _ -> Nothing
 
-    case computeLatestSignal args lookback pricesV highsV lowsV mLstmCtx mKalmanCtx mMarketModel mPredHistory of
+    case computeLatestSignal args lookback featureInputs mLstmCtx mKalmanCtx mMarketModel mPredHistory of
         Left err -> throwIO (userError err)
         Right sig -> pure sig
 
@@ -20334,7 +20378,13 @@ computeBacktestSummary args lookback series mBinanceEnv = do
                 )
             )
 
-    let opensAll = fromMaybe prices (matchLengthAndTrim (psOpen seriesWindow))
+    let opensAll = matchLengthAndTrim (psOpen seriesWindow)
+        opensAllForBars =
+            fromMaybe
+                (case prices of
+                    [] -> []
+                    p0 : _ -> p0 : init prices)
+                opensAll
         (highsAll, lowsAll) =
             case (matchLengthAndTrim (psHigh seriesWindow), matchLengthAndTrim (psLow seriesWindow)) of
                 (Just hs, Just ls)
@@ -20348,12 +20398,12 @@ computeBacktestSummary args lookback series mBinanceEnv = do
         fitPrices = take predStart prices
 
         tunePrices = drop fitSize trainPrices
-        tuneOpens = take tuneSize (drop fitSize opensAll)
+        tuneOpens = fmap (take tuneSize . drop fitSize) opensAll
         tuneHighs = take tuneSize (drop fitSize highsAll)
         tuneLows = take tuneSize (drop fitSize lowsAll)
         tuneOpenTimes = fmap (take tuneSize . drop fitSize) openTimesAll
 
-        backtestOpens = drop trainEnd opensAll
+        backtestOpens = fmap (drop trainEnd) opensAll
         backtestHighs = drop trainEnd highsAll
         backtestLows = drop trainEnd lowsAll
         backtestOpenTimes = fmap (drop trainEnd) openTimesAll
@@ -20392,6 +20442,20 @@ computeBacktestSummary args lookback series mBinanceEnv = do
                     MethodBanditRouter -> MethodBoth
                     _ -> methodRequested
         pricesV = V.fromList prices
+        allFeatureInputs =
+            featureInputsFromLists
+                prices
+                opensAll
+                (Just highsAll)
+                (Just lowsAll)
+                (Just volumesAll)
+        fitFeatureInputs =
+            featureInputsFromLists
+                fitPrices
+                (take predStart <$> opensAll)
+                (Just (take predStart highsAll))
+                (Just (take predStart lowsAll))
+                (Just (take predStart volumesAll))
         highsV = V.fromList highsAll
         lowsV = V.fromList lowsAll
 
@@ -20424,8 +20488,7 @@ computeBacktestSummary args lookback series mBinanceEnv = do
                 obsAll = forwardSeries normState prices
                 obsTrain = take predStart obsAll
             (lstmModel, history) <- trainLstmWithPersistence args lookback lstmCfg obsTrain
-            let fitPricesV = V.fromList fitPrices
-                predictors = trainPredictorsWithMarket (argPredictors args) lookback mMarketModel fitPricesV
+            let predictors = trainPredictorsWithInputsWithMarket (argPredictors args) lookback mMarketModel fitFeatureInputs
                 hmmInitReturns = forwardReturns (take (predStart + 1) prices)
                 hmm0 = initHMMFilter predictors hmmInitReturns
                 kal0 =
@@ -20436,7 +20499,7 @@ computeBacktestSummary args lookback series mBinanceEnv = do
                 sv0 = emptySensorVar
                 (kalFinal, hmmFinal, svFinal, kalPredRev, lstmPredRev, metaRev) =
                     foldl'
-                        (backtestStep args lookback normState obsAll pricesV lstmModel predictors predStart mMarketModel)
+                        (backtestStep args lookback normState obsAll allFeatureInputs lstmModel predictors predStart mMarketModel)
                         (kal0, hmm0, sv0, [], [], [])
                         [0 .. stepCount - 1]
                 kalPred = reverse kalPredRev
@@ -20456,8 +20519,7 @@ computeBacktestSummary args lookback series mBinanceEnv = do
     (mLstmCtx, mHistory, kalPredAll, lstmPredAll, mKalmanCtx, mMetaAll, mPhysicsLatestPred) <-
         case methodForComputation of
             MethodKalmanPhysicsError -> do
-                let fitPricesV = V.fromList fitPrices
-                    predictors = trainPredictorsWithMarket (argPredictors args) lookback mMarketModel fitPricesV
+                let predictors = trainPredictorsWithInputsWithMarket (argPredictors args) lookback mMarketModel fitFeatureInputs
                     hmmInitReturns = forwardReturns (take (predStart + 1) prices)
                     hmm0 = initHMMFilter predictors hmmInitReturns
                     kal0 =
@@ -20468,10 +20530,10 @@ computeBacktestSummary args lookback series mBinanceEnv = do
                     sv0 = emptySensorVar
                     (kalFinal, hmmFinal, svFinal, _kalPredRev, metaRev) =
                         foldl'
-                            (backtestStepKalmanOnly args pricesV predictors predStart mMarketModel)
+                            (backtestStepKalmanOnly args allFeatureInputs predictors predStart mMarketModel)
                             (kal0, hmm0, sv0, [], [])
                             [0 .. stepCount - 1]
-                    opensV = V.fromList opensAll
+                    opensV = V.fromList opensAllForBars
                     highsV' = V.fromList highsAll
                     lowsV' = V.fromList lowsAll
                     closesV = V.fromList prices
@@ -20508,8 +20570,7 @@ computeBacktestSummary args lookback series mBinanceEnv = do
                 let meta = reverse metaRev
                 pure (Nothing, Nothing, kalPred, kalPred, Just (predictors, kalFinal, hmmFinal, svFinal), Just meta, mLatestPred)
             MethodKalmanOnly -> do
-                let fitPricesV = V.fromList fitPrices
-                    predictors = trainPredictorsWithMarket (argPredictors args) lookback mMarketModel fitPricesV
+                let predictors = trainPredictorsWithInputsWithMarket (argPredictors args) lookback mMarketModel fitFeatureInputs
                     hmmInitReturns = forwardReturns (take (predStart + 1) prices)
                     hmm0 = initHMMFilter predictors hmmInitReturns
                     kal0 =
@@ -20520,7 +20581,7 @@ computeBacktestSummary args lookback series mBinanceEnv = do
                     sv0 = emptySensorVar
                     (kalFinal, hmmFinal, svFinal, kalPredRev, metaRev) =
                         foldl'
-                            (backtestStepKalmanOnly args pricesV predictors predStart mMarketModel)
+                            (backtestStepKalmanOnly args allFeatureInputs predictors predStart mMarketModel)
                             (kal0, hmm0, sv0, [], [])
                             [0 .. stepCount - 1]
                     kalPred = reverse kalPredRev
@@ -20711,8 +20772,8 @@ computeBacktestSummary args lookback series mBinanceEnv = do
                 , ecMinPositionSize = argMinPositionSize args
                 }
 
-        baseCfgTune = baseCfg{ecOpenTimes = V.fromList <$> tuneOpenTimes, ecOpenPrices = Just (V.fromList tuneOpens)}
-        baseCfgBacktest = baseCfg{ecOpenTimes = V.fromList <$> backtestOpenTimes, ecOpenPrices = Just (V.fromList backtestOpens)}
+        baseCfgTune = baseCfg{ecOpenTimes = V.fromList <$> tuneOpenTimes, ecOpenPrices = V.fromList <$> tuneOpens}
+        baseCfgBacktest = baseCfg{ecOpenTimes = V.fromList <$> backtestOpenTimes, ecOpenPrices = V.fromList <$> backtestOpens}
 
         offsetBacktestPred = max 0 (trainEnd - predStart)
         kalPredBacktest = drop offsetBacktestPred kalPredAll
@@ -21277,7 +21338,7 @@ computeBacktestSummary args lookback series mBinanceEnv = do
                 else Nothing
 
     latestSignal <-
-        case computeLatestSignal argsForSignal lookback pricesV (Just highsV) (Just lowsV) mLstmCtx mKalmanCtx mMarketModel mPredHistorySignal of
+        case computeLatestSignal argsForSignal lookback allFeatureInputs mLstmCtx mKalmanCtx mMarketModel mPredHistorySignal of
             Left err -> throwIO (userError err)
             Right sig -> pure sig
 
@@ -21904,15 +21965,13 @@ routerPredictionsV openThr roundTripCost pnlWeight lookback minScore pricesV kal
 computeLatestSignal ::
     Args ->
     Int ->
-    V.Vector Double ->
-    Maybe (V.Vector Double) ->
-    Maybe (V.Vector Double) ->
+    FeatureInputs ->
     Maybe LstmCtx ->
     Maybe KalmanCtx ->
     Maybe MarketModel ->
     Maybe PredHistory ->
     Either String LatestSignal
-computeLatestSignal args lookback pricesV mHighsV mLowsV mLstmCtx mKalmanCtx mMarketModel mPredHistory
+computeLatestSignal args lookback featureInputs mLstmCtx mKalmanCtx mMarketModel mPredHistory
     | nAll < 1 = Left ("Need at least 1 price to compute latest signal (got " ++ show nAll ++ ")")
     | methodNeedsLstm && not lstmWindowOk = Left "Not enough data to compute LSTM window for latest signal."
     | otherwise =
@@ -22056,6 +22115,7 @@ computeLatestSignal args lookback pricesV mHighsV mLowsV mLstmCtx mKalmanCtx mMa
         case methodForReport of
             MethodKalmanPhysicsError -> "Method kalman_physics_error requires Kalman context."
             _ -> "Method 10 requires Kalman context."
+    pricesV = fiClose featureInputs
     nAll = V.length pricesV
     methodNeedsLstm =
         case method of
@@ -22232,8 +22292,9 @@ computeLatestSignal args lookback pricesV mHighsV mLowsV mLstmCtx mKalmanCtx mMa
                         | V.length v > n -> Just (V.drop (V.length v - n) v)
                     _ -> Nothing
 
-            highsV = alignVector mHighsV
-            lowsV = alignVector mLowsV
+            opensV = alignVector (fiOpen featureInputs)
+            highsV = alignVector (fiHigh featureInputs)
+            lowsV = alignVector (fiLow featureInputs)
 
             returnsFromPrices =
                 case n of
@@ -22429,7 +22490,11 @@ computeLatestSignal args lookback pricesV mHighsV mLowsV mLstmCtx mKalmanCtx mMa
 
             candleAt i =
                 let c = pricesV V.! i
-                    o = if i <= 0 then c else pricesV V.! (i - 1)
+                    prevClose = if i <= 0 then c else pricesV V.! (i - 1)
+                    oRaw =
+                        case opensV of
+                            Just ov | i >= 0 && i < V.length ov -> ov V.! i
+                            _ -> prevClose
                     hRaw =
                         case highsV of
                             Just hv | i >= 0 && i < V.length hv -> hv V.! i
@@ -22438,8 +22503,9 @@ computeLatestSignal args lookback pricesV mHighsV mLowsV mLstmCtx mKalmanCtx mMa
                         case lowsV of
                             Just lv | i >= 0 && i < V.length lv -> lv V.! i
                             _ -> c
-                    h = if bad hRaw then c else hRaw
-                    l = if bad lRaw then c else lRaw
+                    o = if bad oRaw then prevClose else oRaw
+                    h = max (max o c) (if bad hRaw then c else hRaw)
+                    l = min (min o c) (if bad lRaw then c else lRaw)
                  in (o, h, l, c)
 
             candleOpen (o, _, _, _) = o
@@ -22583,7 +22649,7 @@ computeLatestSignal args lookback pricesV mHighsV mLowsV mLstmCtx mKalmanCtx mMa
                 case mKalmanCtx of
                     Nothing -> (Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Just 0, Nothing)
                     Just (predictors, kalPrev, hmmPrev, svPrev) ->
-                        let (sensorOuts, _) = predictSensors predictors pricesV hmmPrev t
+                        let (sensorOuts, _) = predictSensorsWithInputs predictors featureInputs hmmPrev t
                             mReg = listToMaybe [r | (_sid, out) <- sensorOuts, Just r <- [soRegimes out]]
                             mQ = listToMaybe [q | (_sid, out) <- sensorOuts, Just q <- [soQuantiles out]]
                             mI = listToMaybe [i | (_sid, out) <- sensorOuts, Just i <- [soInterval out]]
@@ -23023,7 +23089,7 @@ computeLatestSignal args lookback pricesV mHighsV mLowsV mLstmCtx mKalmanCtx mMa
                                                 sv0 = emptySensorVar
                                                 (_, _, _, kalPredRev, metaRev) =
                                                     foldl'
-                                                        (backtestStepKalmanOnly args pricesV predictors 0 mMarketModel)
+                                                        (backtestStepKalmanOnly args featureInputs predictors 0 mMarketModel)
                                                         (kal0, hmm0, sv0, [], [])
                                                         [0 .. stepCount - 1]
                                                 kalPredV = V.fromList (reverse kalPredRev)
@@ -24634,6 +24700,30 @@ data PriceSeries = PriceSeries
     }
     deriving (Eq, Show)
 
+featureInputsFromSeries :: PriceSeries -> FeatureInputs
+featureInputsFromSeries series =
+    mkFeatureInputs
+        (V.fromList (psClose series))
+        (V.fromList <$> psOpen series)
+        (V.fromList <$> psHigh series)
+        (V.fromList <$> psLow series)
+        (V.fromList <$> psVolume series)
+
+featureInputsFromLists ::
+    [Double] ->
+    Maybe [Double] ->
+    Maybe [Double] ->
+    Maybe [Double] ->
+    Maybe [Double] ->
+    FeatureInputs
+featureInputsFromLists closes opens highs lows volumes =
+    mkFeatureInputs
+        (V.fromList closes)
+        (V.fromList <$> opens)
+        (V.fromList <$> highs)
+        (V.fromList <$> lows)
+        (V.fromList <$> volumes)
+
 priceSourceLabel :: Args -> String
 priceSourceLabel args =
     if prefersCsvBars args
@@ -24938,20 +25028,21 @@ toMeasurement args sv (sid, out) =
 
 backtestStepKalmanOnly ::
     Args ->
-    V.Vector Double ->
+    FeatureInputs ->
     PredictorBundle ->
     Int ->
     Maybe MarketModel ->
     (Kalman1, HMMFilter, SensorVar, [Double], [StepMeta]) ->
     Int ->
     (Kalman1, HMMFilter, SensorVar, [Double], [StepMeta])
-backtestStepKalmanOnly args pricesV predictors trainEnd mMarketModel (kal, hmm, sv, kalAcc, metaAcc) i =
-    let t = trainEnd + i
+backtestStepKalmanOnly args inputs predictors trainEnd mMarketModel (kal, hmm, sv, kalAcc, metaAcc) i =
+    let pricesV = fiClose inputs
+        t = trainEnd + i
         priceT = pricesV V.! t
         nextP = pricesV V.! (t + 1)
         realizedR = if priceT == 0 then 0 else nextP / priceT - 1
 
-        (sensorOuts, predState) = predictSensors predictors pricesV hmm t
+        (sensorOuts, predState) = predictSensorsWithInputs predictors inputs hmm t
         mReg = listToMaybe [r | (_sid, out) <- sensorOuts, Just r <- [soRegimes out]]
         mQ = listToMaybe [q | (_sid, out) <- sensorOuts, Just q <- [soQuantiles out]]
         mI = listToMaybe [i' | (_sid, out) <- sensorOuts, Just i' <- [soInterval out]]
@@ -24983,7 +25074,7 @@ backtestStep ::
     Int ->
     NormState ->
     [Double] ->
-    V.Vector Double ->
+    FeatureInputs ->
     LSTMModel ->
     PredictorBundle ->
     Int ->
@@ -24991,13 +25082,14 @@ backtestStep ::
     (Kalman1, HMMFilter, SensorVar, [Double], [Double], [StepMeta]) ->
     Int ->
     (Kalman1, HMMFilter, SensorVar, [Double], [Double], [StepMeta])
-backtestStep args lookback normState obsAll pricesV lstmModel predictors trainEnd mMarketModel (kal, hmm, sv, kalAcc, lstmAcc, metaAcc) i =
-    let t = trainEnd + i
+backtestStep args lookback normState obsAll inputs lstmModel predictors trainEnd mMarketModel (kal, hmm, sv, kalAcc, lstmAcc, metaAcc) i =
+    let pricesV = fiClose inputs
+        t = trainEnd + i
         priceT = pricesV V.! t
         nextP = pricesV V.! (t + 1)
         realizedR = if priceT == 0 then 0 else nextP / priceT - 1
 
-        (sensorOuts, predState) = predictSensors predictors pricesV hmm t
+        (sensorOuts, predState) = predictSensorsWithInputs predictors inputs hmm t
         mReg = listToMaybe [r | (_sid, out) <- sensorOuts, Just r <- [soRegimes out]]
         mQ = listToMaybe [q | (_sid, out) <- sensorOuts, Just q <- [soQuantiles out]]
         mI = listToMaybe [i' | (_sid, out) <- sensorOuts, Just i' <- [soInterval out]]

--- a/haskell/app/Trader/App/Args.hs
+++ b/haskell/app/Trader/App/Args.hs
@@ -605,7 +605,7 @@ opts = do
             ( long "predictors"
                 <> value allPredictors
                 <> showDefaultWith predictorSetToCsv
-                <> help "Comma-separated predictors to train/use (gbdt,tcn,transformer,hmm,quantile,conformal, all, none)"
+                <> help "Comma-separated predictors to train/use (gbdt,knn,decision_tree,tcn,transformer,hmm,quantile,conformal, all, none)"
             )
     argKalmanMarketTopN <-
         option

--- a/haskell/app/Trader/Coinbase.hs
+++ b/haskell/app/Trader/Coinbase.hs
@@ -8,6 +8,7 @@ module Trader.Coinbase (
     newCoinbaseEnv,
     fetchCoinbaseAccounts,
     fetchCoinbaseAvailableBalance,
+    fetchCoinbaseBaseMinSize,
     fetchCoinbaseCandles,
     decodeCoinbaseCandles,
     buildRanges,
@@ -19,7 +20,7 @@ import Control.Exception (throwIO)
 import qualified Control.Monad
 import Crypto.Hash (SHA256)
 import Crypto.MAC.HMAC (HMAC, hmac, hmacGetDigest)
-import Data.Aeson (FromJSON (..), Value (..), eitherDecode, encode, object, withArray, withObject, (.:), (.=))
+import Data.Aeson (FromJSON (..), Value (..), eitherDecode, encode, object, withArray, withObject, (.:), (.:?), (.=))
 import qualified Data.Aeson.Types as AT
 import qualified Data.ByteArray as BA
 import qualified Data.ByteArray.Encoding as BAE
@@ -120,6 +121,28 @@ fetchCoinbaseAvailableBalance env currency = do
     let target = map toUpperAscii (trim currency)
         match = find (\acct -> map toUpperAscii (caCurrency acct) == target) accounts
     pure (maybe 0 caAvailable match)
+
+fetchCoinbaseBaseMinSize :: CoinbaseEnv -> String -> IO (Maybe Double)
+fetchCoinbaseBaseMinSize env product = do
+    let cleanedProduct = map toUpperAscii (trim product)
+    req0 <- parseRequest (ceBaseUrl env ++ "/products/" ++ cleanedProduct)
+    let req =
+            req0
+                { requestHeaders =
+                    ("User-Agent", BS8.pack "trader-hs/0.1")
+                        : ("Accept", BS8.pack "application/json")
+                        : requestHeaders req0
+                , responseTimeout = responseTimeoutMicro coinbaseTimeoutMicros
+                }
+    resp <- coinbaseHttp env "coinbase.product" req
+    ensure2xx "Coinbase product" resp
+    payload <-
+        case eitherDecode (responseBody resp) of
+            Left err -> throwIO (userError ("Failed to decode Coinbase product: " ++ err))
+            Right ok -> pure ok
+    case AT.parseEither parseCoinbaseBaseMinSize payload of
+        Left err -> throwIO (userError ("Failed to parse Coinbase product: " ++ err))
+        Right minQty -> pure minQty
 
 placeCoinbaseMarketOrder :: CoinbaseEnv -> String -> String -> Maybe Double -> Maybe Double -> Maybe String -> IO BL.ByteString
 placeCoinbaseMarketOrder env product sideRaw mSizeRaw mFundsRaw mClientOrderId = do
@@ -257,6 +280,19 @@ parseIndexDouble i arr =
     case arr V.!? i of
         Nothing -> fail "Missing index"
         Just v -> parseDoubleValue v
+
+parseCoinbaseBaseMinSize :: Value -> AT.Parser (Maybe Double)
+parseCoinbaseBaseMinSize =
+    withObject "CoinbaseProduct" $ \o -> do
+        mRaw <- o .:? "base_min_size"
+        case mRaw of
+            Nothing -> pure Nothing
+            Just v -> do
+                qty <- parseDoubleValue v
+                pure $
+                    if qty > 0
+                        then Just qty
+                        else Nothing
 
 parseInt64Value :: Value -> AT.Parser Int64
 parseInt64Value v =

--- a/haskell/app/Trader/Predictors.hs
+++ b/haskell/app/Trader/Predictors.hs
@@ -10,8 +10,11 @@ module Trader.Predictors (
     HMM3 (..),
     trainPredictors,
     trainPredictorsWithMarket,
+    trainPredictorsWithInputs,
+    trainPredictorsWithInputsWithMarket,
     initHMMFilter,
     predictSensors,
+    predictSensorsWithInputs,
     updateHMM,
 ) where
 
@@ -19,15 +22,19 @@ import qualified Data.Vector as V
 
 import Trader.MarketContext (MarketModel)
 import Trader.Predictors.Conformal (ConformalModel (..), fitConformal, predictInterval)
+import Trader.Predictors.DecisionTree (DecisionTreeModel (..), predictDecisionTree, trainDecisionTree)
 import Trader.Predictors.Features (
+    FeatureInputs (..),
     FeatureSpec,
-    buildDatasetWithIndexWithMarket,
-    featuresAtWithMarket,
+    buildDatasetWithIndexWithInputsWithMarket,
+    featureInputsFromClose,
+    featuresAtWithInputsWithMarket,
     forwardReturnAt,
     mkFeatureSpec,
  )
 import Trader.Predictors.GBDT (GBDTModel (..), predictGBDT, trainGBDT)
 import Trader.Predictors.HMM (HMM3 (..), HMMFilter (..), filterPosterior, fitHMM3, predictNextFromPosterior, updatePosterior)
+import Trader.Predictors.KNN (KNNModel (..), predictKNN, trainKNN)
 import Trader.Predictors.Quantile (LinModel (..), QuantileModel (..), predictQuantiles, trainQuantileModel)
 import Trader.Predictors.TCN (TCNModel (..), predictTCN, trainTCN)
 import Trader.Predictors.Transformer (TransformerModel (..), predictTransformer, trainTransformer)
@@ -46,6 +53,8 @@ data PredictorBundle = PredictorBundle
     , pbFeatureSpec :: !FeatureSpec
     , pbMarketModel :: !(Maybe MarketModel)
     , pbGBDT :: !GBDTModel
+    , pbKNN :: !KNNModel
+    , pbDecisionTree :: !DecisionTreeModel
     , pbTCN :: !TCNModel
     , pbTransformer :: !TransformerModel
     , pbQuantile :: !QuantileModel
@@ -60,17 +69,28 @@ trainPredictors enabled lookbackBars =
 
 trainPredictorsWithMarket :: PredictorSet -> Int -> Maybe MarketModel -> V.Vector Double -> PredictorBundle
 trainPredictorsWithMarket enabled lookbackBars mMarketModel trainPrices =
+    trainPredictorsWithInputsWithMarket enabled lookbackBars mMarketModel (featureInputsFromClose trainPrices)
+
+trainPredictorsWithInputs :: PredictorSet -> Int -> FeatureInputs -> PredictorBundle
+trainPredictorsWithInputs enabled lookbackBars =
+    trainPredictorsWithInputsWithMarket enabled lookbackBars Nothing
+
+trainPredictorsWithInputsWithMarket :: PredictorSet -> Int -> Maybe MarketModel -> FeatureInputs -> PredictorBundle
+trainPredictorsWithInputsWithMarket enabled lookbackBars mMarketModel trainInputs =
     let fs = mkFeatureSpec lookbackBars
+        trainPrices = fiClose trainInputs
         useGbdt = predictorEnabled enabled SensorGBT
+        useKnn = predictorEnabled enabled SensorKNN
+        useDecisionTree = predictorEnabled enabled SensorDecisionTree
         useTcn = predictorEnabled enabled SensorTCN
         useTransformer = predictorEnabled enabled SensorTransformer
         useHmm = predictorEnabled enabled SensorHMM
         useQuantile = predictorEnabled enabled SensorQuantile
         useConformal = predictorEnabled enabled SensorConformal
-        needFeatures = useGbdt || useTransformer || useQuantile || useConformal
+        needFeatures = useGbdt || useKnn || useDecisionTree || useTransformer || useQuantile || useConformal
         datasetWithIndex =
             if needFeatures
-                then buildDatasetWithIndexWithMarket fs mMarketModel trainPrices
+                then buildDatasetWithIndexWithInputsWithMarket fs mMarketModel trainInputs
                 else []
         (trainSetIdx, calibIdx) =
             if needFeatures
@@ -102,6 +122,23 @@ trainPredictorsWithMarket enabled lookbackBars mMarketModel trainPrices =
                 , gmStumps = []
                 , gmSigma = Nothing
                 }
+        emptyKnn =
+            KNNModel
+                { kmK = 0
+                , kmFeatureDim = 0
+                , kmMeans = []
+                , kmScales = []
+                , kmExamples = []
+                , kmSigmaBase = Nothing
+                }
+        emptyDecisionTree =
+            DecisionTreeModel
+                { dmFeatureDim = 0
+                , dmMaxDepth = 0
+                , dmMinLeafSize = 0
+                , dmRoot = Nothing
+                , dmSigmaBase = Nothing
+                }
         emptyLin = LinModel{lmW = [], lmB = 0}
         emptyQuant = QuantileModel emptyLin emptyLin emptyLin
         emptyTransformer = TransformerModel{trKeys = [], trTargets = [], trTemperature = 0, trFeatureDim = 0}
@@ -118,6 +155,20 @@ trainPredictorsWithMarket enabled lookbackBars mMarketModel trainPrices =
             | not gbdtTrained = emptyGbdt
             | null trainSet = emptyGbdt
             | otherwise = trainGBDT 60 0.1 trainSet
+        knn =
+            if useKnn
+                then
+                    if null trainSet
+                        then emptyKnn
+                        else trainKNN 1024 15 trainSet
+                else emptyKnn
+        decisionTree =
+            if useDecisionTree
+                then
+                    if null trainSet
+                        then emptyDecisionTree
+                        else trainDecisionTree 6 12 trainSet
+                else emptyDecisionTree
         quant =
             if useQuantile
                 then
@@ -141,7 +192,6 @@ trainPredictorsWithMarket enabled lookbackBars mMarketModel trainPrices =
             if useHmm
                 then fitHMM3 10 hmmObs
                 else fitHMM3 0 []
-        -- Conformal: calibrate on a holdout split (last 20%).
         absRes =
             if useConformal
                 then
@@ -171,6 +221,8 @@ trainPredictorsWithMarket enabled lookbackBars mMarketModel trainPrices =
             , pbFeatureSpec = fs
             , pbMarketModel = mMarketModel
             , pbGBDT = gbdt
+            , pbKNN = knn
+            , pbDecisionTree = decisionTree
             , pbTCN = tcn
             , pbTransformer = transformer
             , pbQuantile = quant
@@ -202,20 +254,34 @@ predictSensors ::
     Int ->
     ([(SensorId, SensorOutput)], [Double])
 predictSensors pb prices hmmFilt t =
+    predictSensorsWithInputs pb (featureInputsFromClose prices) hmmFilt t
+
+predictSensorsWithInputs ::
+    PredictorBundle ->
+    FeatureInputs ->
+    HMMFilter ->
+    Int ->
+    ([(SensorId, SensorOutput)], [Double])
+predictSensorsWithInputs pb inputs hmmFilt t =
     let fs = pbFeatureSpec pb
         enabled = pbEnabled pb
+        prices = fiClose inputs
         useGbdt = predictorEnabled enabled SensorGBT
+        useKnn = predictorEnabled enabled SensorKNN
+        useDecisionTree = predictorEnabled enabled SensorDecisionTree
         useTcn = predictorEnabled enabled SensorTCN
         useTransformer = predictorEnabled enabled SensorTransformer
         useHmm = predictorEnabled enabled SensorHMM
         useQuantile = predictorEnabled enabled SensorQuantile
         useConformal = predictorEnabled enabled SensorConformal
-        needFeatures = useGbdt || useTransformer || useQuantile || useConformal
+        needFeatures = useGbdt || useKnn || useDecisionTree || useTransformer || useQuantile || useConformal
         feat =
             if needFeatures
-                then featuresAtWithMarket fs (pbMarketModel pb) prices t
+                then featuresAtWithInputsWithMarket fs (pbMarketModel pb) inputs t
                 else Nothing
         gbdtReady = gmFeatureDim (pbGBDT pb) > 0
+        knnReady = kmFeatureDim (pbKNN pb) > 0
+        decisionTreeReady = dmFeatureDim (pbDecisionTree pb) > 0
         quantReady = not (null (lmW (qm50 (pbQuantile pb))))
         transformerReady = trFeatureDim (pbTransformer pb) > 0
         gbdtPred =
@@ -232,6 +298,26 @@ predictSensors pb prices hmmFilt t =
                     | useGbdt ->
                         [(SensorGBT, SensorOutput{soMu = mu, soSigma = sig, soRegimes = Nothing, soQuantiles = Nothing, soInterval = Nothing})]
                 _ -> []
+
+        knnOut =
+            case feat of
+                Nothing -> []
+                Just x ->
+                    if not useKnn || not knnReady || length x /= kmFeatureDim (pbKNN pb)
+                        then []
+                        else
+                            let (mu, sig) = predictKNN (pbKNN pb) x
+                             in [(SensorKNN, SensorOutput{soMu = mu, soSigma = sig, soRegimes = Nothing, soQuantiles = Nothing, soInterval = Nothing})]
+
+        decisionTreeOut =
+            case feat of
+                Nothing -> []
+                Just x ->
+                    if not useDecisionTree || not decisionTreeReady || length x /= dmFeatureDim (pbDecisionTree pb)
+                        then []
+                        else
+                            let (mu, sig) = predictDecisionTree (pbDecisionTree pb) x
+                             in [(SensorDecisionTree, SensorOutput{soMu = mu, soSigma = sig, soRegimes = Nothing, soQuantiles = Nothing, soInterval = Nothing})]
 
         tcnOut =
             if not useTcn
@@ -309,7 +395,7 @@ predictSensors pb prices hmmFilt t =
                             ]
                         , predState'
                         )
-     in (gbdtOut ++ tcnOut ++ transformerOut ++ hmmOut ++ quantOut ++ conformalOut, predState)
+     in (gbdtOut ++ knnOut ++ decisionTreeOut ++ tcnOut ++ transformerOut ++ hmmOut ++ quantOut ++ conformalOut, predState)
 
 updateHMM :: PredictorBundle -> [Double] -> Double -> HMMFilter
 updateHMM pb predState realizedReturn =

--- a/haskell/app/Trader/Predictors/DecisionTree.hs
+++ b/haskell/app/Trader/Predictors/DecisionTree.hs
@@ -1,0 +1,241 @@
+module Trader.Predictors.DecisionTree (
+    DecisionTree (..),
+    DecisionTreeModel (..),
+    trainDecisionTree,
+    predictDecisionTree,
+) where
+
+import Data.List (minimumBy, sort)
+import Data.Ord (comparing)
+
+import Trader.Text (dedupeStable)
+
+data DecisionTree
+    = DecisionLeaf
+        { dtValue :: !Double
+        , dtSigma :: !(Maybe Double)
+        , dtCount :: !Int
+        }
+    | DecisionNode
+        { dtFeature :: !Int
+        , dtThreshold :: !Double
+        , dtLeft :: !DecisionTree
+        , dtRight :: !DecisionTree
+        }
+    deriving (Eq, Show)
+
+data DecisionTreeModel = DecisionTreeModel
+    { dmFeatureDim :: !Int
+    , dmMaxDepth :: !Int
+    , dmMinLeafSize :: !Int
+    , dmRoot :: !(Maybe DecisionTree)
+    , dmSigmaBase :: !(Maybe Double)
+    }
+    deriving (Eq, Show)
+
+trainDecisionTree :: Int -> Int -> [([Double], Double)] -> DecisionTreeModel
+trainDecisionTree maxDepth minLeafSize dataset
+    | maxDepth <= 0 = emptyDecisionTreeModel
+    | minLeafSize <= 0 = emptyDecisionTreeModel
+    | null dataset = emptyDecisionTreeModel
+    | otherwise =
+        let ds = sanitizeDataset dataset
+            featureDim = featureDimFromDataset ds
+         in if featureDim <= 0 || null ds
+                then emptyDecisionTreeModel
+                else
+                    let sigmaBase = sigmaFromTargets (map snd ds)
+                        root = buildTree sigmaBase maxDepth minLeafSize ds
+                     in DecisionTreeModel
+                            { dmFeatureDim = featureDim
+                            , dmMaxDepth = maxDepth
+                            , dmMinLeafSize = minLeafSize
+                            , dmRoot = Just root
+                            , dmSigmaBase = sigmaBase
+                            }
+
+predictDecisionTree :: DecisionTreeModel -> [Double] -> (Double, Maybe Double)
+predictDecisionTree model feats =
+    let expected = dmFeatureDim model
+        queryOk = expected > 0 && length feats == expected && all isFiniteDouble feats
+     in if not queryOk
+            then (0, dmSigmaBase model)
+            else case dmRoot model of
+                Nothing -> (0, dmSigmaBase model)
+                Just root ->
+                    let (mu, mSigma) = go root
+                     in if isFiniteDouble mu
+                            then (mu, mSigma <|> dmSigmaBase model)
+                            else (0, dmSigmaBase model)
+  where
+    go tree =
+        case tree of
+            DecisionLeaf value sigma _count -> (value, sigma)
+            DecisionNode feature threshold left right ->
+                if feature < 0 || feature >= length feats
+                    then (0, dmSigmaBase model)
+                    else
+                        let x = feats !! feature
+                         in if x <= threshold then go left else go right
+
+    (<|>) left right =
+        case left of
+            Just _ -> left
+            Nothing -> right
+
+emptyDecisionTreeModel :: DecisionTreeModel
+emptyDecisionTreeModel =
+    DecisionTreeModel
+        { dmFeatureDim = 0
+        , dmMaxDepth = 0
+        , dmMinLeafSize = 0
+        , dmRoot = Nothing
+        , dmSigmaBase = Nothing
+        }
+
+sanitizeDataset :: [([Double], Double)] -> [([Double], Double)]
+sanitizeDataset dataset =
+    let finiteRows =
+            [ (x, y)
+            | (x, y) <- dataset
+            , not (null x)
+            , all isFiniteDouble x
+            , isFiniteDouble y
+            ]
+     in case finiteRows of
+            [] -> []
+            ((x0, _) : _) ->
+                let featureDim = length x0
+                 in filter ((== featureDim) . length . fst) finiteRows
+
+featureDimFromDataset :: [([Double], Double)] -> Int
+featureDimFromDataset dataset =
+    case map (length . fst) dataset of
+        [] -> 0
+        d : ds
+            | d <= 0 -> 0
+            | any (/= d) ds -> 0
+            | otherwise -> d
+
+buildTree :: Maybe Double -> Int -> Int -> [([Double], Double)] -> DecisionTree
+buildTree sigmaBase depthLeft minLeafSize rows =
+    let leaf = mkLeaf sigmaBase rows
+        targets = map snd rows
+        currentSse = sumSqErr (mean targets) targets
+     in if depthLeft <= 0 || length rows < 2 * minLeafSize || currentSse <= 1e-12
+            then leaf
+            else case bestSplit minLeafSize rows of
+                Nothing -> leaf
+                Just (_, _, _leftRows, _rightRows, bestSse)
+                    | bestSse >= currentSse - 1e-9 -> leaf
+                Just (feature, threshold, leftRows, rightRows, _bestSse) ->
+                    DecisionNode
+                        { dtFeature = feature
+                        , dtThreshold = threshold
+                        , dtLeft = buildTree sigmaBase (depthLeft - 1) minLeafSize leftRows
+                        , dtRight = buildTree sigmaBase (depthLeft - 1) minLeafSize rightRows
+                        }
+
+mkLeaf :: Maybe Double -> [([Double], Double)] -> DecisionTree
+mkLeaf sigmaBase rows =
+    let ys = map snd rows
+        value = mean ys
+        sigma = sigmaFromTargets ys <|> sigmaBase
+     in DecisionLeaf
+            { dtValue = if isFiniteDouble value then value else 0
+            , dtSigma = sigma
+            , dtCount = length rows
+            }
+  where
+    (<|>) left right =
+        case left of
+            Just _ -> left
+            Nothing -> right
+
+bestSplit :: Int -> [([Double], Double)] -> Maybe (Int, Double, [([Double], Double)], [([Double], Double)], Double)
+bestSplit minLeafSize rows =
+    let featureDim = featureDimFromDataset rows
+        candidates =
+            [ bestForFeature feature
+            | feature <- [0 .. featureDim - 1]
+            ]
+        valids =
+            [ split
+            | Just split <- candidates
+            ]
+     in case valids of
+            [] -> Nothing
+            _ -> Just (minimumBy (comparing (\(_, _, _, _, sse) -> sse)) valids)
+  where
+    bestForFeature feature =
+        let xs = [x !! feature | (x, _y) <- rows]
+            thresholds = candidateThresholds xs
+            options =
+                [ let (leftRows, rightRows) = partitionRows feature threshold rows
+                      leftTargets = map snd leftRows
+                      rightTargets = map snd rightRows
+                      score = sumSqErr (mean leftTargets) leftTargets + sumSqErr (mean rightTargets) rightTargets
+                   in if length leftRows < minLeafSize || length rightRows < minLeafSize
+                        then Nothing
+                        else Just (feature, threshold, leftRows, rightRows, score)
+                | threshold <- thresholds
+                ]
+         in case [v | Just v <- options] of
+                [] -> Nothing
+                vs -> Just (minimumBy (comparing (\(_, _, _, _, sse) -> sse)) vs)
+
+partitionRows :: Int -> Double -> [([Double], Double)] -> ([([Double], Double)], [([Double], Double)])
+partitionRows feature threshold =
+    foldr
+        ( \(x, y) (leftRows, rightRows) ->
+            if x !! feature <= threshold
+                then ((x, y) : leftRows, rightRows)
+                else (leftRows, (x, y) : rightRows)
+        )
+        ([], [])
+
+candidateThresholds :: [Double] -> [Double]
+candidateThresholds xs =
+    let s = sort xs
+        n = length s
+        buckets = 16 :: Int
+        atDef i ys fallback =
+            case drop i ys of
+                v : _ -> v
+                [] -> fallback
+     in if n < 3
+            then []
+            else
+                let fallback =
+                        case s of
+                            v : _ -> v
+                            [] -> 0
+                    ix q =
+                        max
+                            1
+                            (min (n - 2) (floor (fromIntegral q * fromIntegral n / fromIntegral buckets)))
+                    rawThresholds = [atDef (ix q) s fallback | q <- [1 .. buckets - 2]]
+                 in dedupeStable rawThresholds
+
+sigmaFromTargets :: [Double] -> Maybe Double
+sigmaFromTargets ys =
+    case ys of
+        [] -> Nothing
+        [_] -> Just 1e-6
+        _ ->
+            let mu = mean ys
+                var = sum (map (\y -> (y - mu) * (y - mu)) ys) / fromIntegral (length ys - 1)
+                sigma = sqrt (max 0 var + 1e-12)
+             in if isFiniteDouble sigma then Just sigma else Nothing
+
+sumSqErr :: Double -> [Double] -> Double
+sumSqErr mu ys = sum (map (\y -> let e = y - mu in e * e) ys)
+
+mean :: [Double] -> Double
+mean xs =
+    case xs of
+        [] -> 0
+        _ -> sum xs / fromIntegral (length xs)
+
+isFiniteDouble :: Double -> Bool
+isFiniteDouble x = not (isNaN x || isInfinite x)

--- a/haskell/app/Trader/Predictors/Features.hs
+++ b/haskell/app/Trader/Predictors/Features.hs
@@ -1,13 +1,22 @@
 module Trader.Predictors.Features (
     FeatureSpec (..),
+    FeatureInputs (..),
     mkFeatureSpec,
+    mkFeatureInputs,
+    featureInputsFromClose,
     featuresAt,
     featuresAtWithMarket,
+    featuresAtWithInputs,
+    featuresAtWithInputsWithMarket,
     forwardReturnAt,
     buildDatasetWithIndex,
     buildDatasetWithIndexWithMarket,
+    buildDatasetWithIndexWithInputs,
+    buildDatasetWithIndexWithInputsWithMarket,
     buildDataset,
     buildDatasetWithMarket,
+    buildDatasetWithInputs,
+    buildDatasetWithInputsWithMarket,
 ) where
 
 import qualified Data.Vector as V
@@ -21,12 +30,49 @@ data FeatureSpec = FeatureSpec
     }
     deriving (Eq, Show)
 
+data FeatureInputs = FeatureInputs
+    { fiClose :: !(V.Vector Double)
+    , fiOpen :: !(Maybe (V.Vector Double))
+    , fiHigh :: !(Maybe (V.Vector Double))
+    , fiLow :: !(Maybe (V.Vector Double))
+    , fiVolume :: !(Maybe (V.Vector Double))
+    }
+    deriving (Eq, Show)
+
+data Bar = Bar
+    { barOpen :: !Double
+    , barHigh :: !Double
+    , barLow :: !Double
+    , barClose :: !Double
+    , barVolume :: !Double
+    }
+    deriving (Eq, Show)
+
 mkFeatureSpec :: Int -> FeatureSpec
 mkFeatureSpec lookbackBars =
     let lb = max 2 lookbackBars
         shortB = max 1 (min 12 (lb - 1))
         midB = max 1 (min 48 (lb - 1))
      in FeatureSpec{fsLookbackBars = lb, fsShortBars = shortB, fsMidBars = midB}
+
+mkFeatureInputs ::
+    V.Vector Double ->
+    Maybe (V.Vector Double) ->
+    Maybe (V.Vector Double) ->
+    Maybe (V.Vector Double) ->
+    Maybe (V.Vector Double) ->
+    FeatureInputs
+mkFeatureInputs closes opens highs lows volumes =
+    FeatureInputs
+        { fiClose = closes
+        , fiOpen = opens
+        , fiHigh = highs
+        , fiLow = lows
+        , fiVolume = volumes
+        }
+
+featureInputsFromClose :: V.Vector Double -> FeatureInputs
+featureInputsFromClose closes = mkFeatureInputs closes Nothing Nothing Nothing Nothing
 
 -- | Forward return r_t = p_{t+1}/p_t - 1.
 forwardReturnAt :: V.Vector Double -> Int -> Maybe Double
@@ -42,33 +88,46 @@ forwardReturnAt prices t =
 Requires at least fsLookbackBars history (prices window ending at t).
 -}
 featuresAt :: FeatureSpec -> V.Vector Double -> Int -> Maybe [Double]
-featuresAt fs = featuresAtWithMarket fs Nothing
+featuresAt fs prices = featuresAtWithInputsWithMarket fs Nothing (featureInputsFromClose prices)
 
 {- | Market-aware feature vector at bar t using only data available by bar t.
 Cross-symbol features fall back to zero when market context is missing/invalid.
 -}
 featuresAtWithMarket :: FeatureSpec -> Maybe MarketModel -> V.Vector Double -> Int -> Maybe [Double]
-featuresAtWithMarket fs mMarket prices t = do
-    let lb = fsLookbackBars fs
+featuresAtWithMarket fs mMarket prices = featuresAtWithInputsWithMarket fs mMarket (featureInputsFromClose prices)
+
+featuresAtWithInputs :: FeatureSpec -> FeatureInputs -> Int -> Maybe [Double]
+featuresAtWithInputs fs = featuresAtWithInputsWithMarket fs Nothing
+
+{- | Market-aware feature vector using close/open/high/low/volume context when
+available. Missing OHLCV fields fall back to synthetic values so the feature
+dimension stays stable across CSV, exchange, and close-only call sites.
+-}
+featuresAtWithInputsWithMarket :: FeatureSpec -> Maybe MarketModel -> FeatureInputs -> Int -> Maybe [Double]
+featuresAtWithInputsWithMarket fs mMarket inputs t = do
+    let closes = fiClose inputs
+        lb = fsLookbackBars fs
         maxLag = max 1 (lb - 1)
         shortB = min (fsShortBars fs) maxLag
         midB = min (fsMidBars fs) maxLag
         ret3Bars = min 3 maxLag
-    if t < lb - 1 || t >= V.length prices
+    if t < lb - 1 || t >= V.length closes
         then Nothing
         else do
-            ret1 <- retOver prices t 1
-            ret3 <- retOver prices t ret3Bars
-            retShort <- retOver prices t shortB
-            retMid <- retOver prices t midB
-            retLb <- retOver prices t (lb - 1)
-            rsShort <- returnsEndingAt prices t shortB
-            rsMid <- returnsEndingAt prices t midB
+            ret1 <- retOver closes t 1
+            ret3 <- retOver closes t ret3Bars
+            retShort <- retOver closes t shortB
+            retMid <- retOver closes t midB
+            retLb <- retOver closes t (lb - 1)
+            rsShort <- returnsEndingAt closes t shortB
+            rsMid <- returnsEndingAt closes t midB
+            barNow <- barAt inputs t
             let (muS, sigS) = meanStd rsShort
                 (muM, sigM) = meanStd rsMid
-                priceT = prices V.! t
+                priceT = barClose barNow
                 psych = psychologicalFeatures priceT
                 marketFeats = marketFeaturesFromModel mMarket t ret1 rsShort
+                klineFeats = klineFeatures inputs barNow t ret1 retShort retMid rsShort rsMid shortB midB
                 eps = 1e-12
                 retSpread = retShort - retMid
                 retMeanReversion = ret1 - muS
@@ -89,6 +148,7 @@ featuresAtWithMarket fs mMarket prices t = do
                     , volRatio
                     , trendSlope
                     ]
+                        ++ klineFeats
                         ++ marketFeats
                         ++ psych
             if all isFiniteDouble feats
@@ -99,150 +159,48 @@ featuresAtWithMarket fs mMarket prices t = do
 Uses t in [lookbackBars-1 .. n-2].
 -}
 buildDatasetWithIndex :: FeatureSpec -> V.Vector Double -> [(Int, [Double], Double)]
-buildDatasetWithIndex fs = buildDatasetWithIndexWithMarket fs Nothing
+buildDatasetWithIndex fs = buildDatasetWithIndexWithInputsWithMarket fs Nothing . featureInputsFromClose
 
 {- | Market-aware dataset builder; cross-symbol features fall back to zero when
 market context is missing/invalid.
 -}
 buildDatasetWithIndexWithMarket :: FeatureSpec -> Maybe MarketModel -> V.Vector Double -> [(Int, [Double], Double)]
-buildDatasetWithIndexWithMarket fs mMarket prices =
-    let n = V.length prices
+buildDatasetWithIndexWithMarket fs mMarket = buildDatasetWithIndexWithInputsWithMarket fs mMarket . featureInputsFromClose
+
+buildDatasetWithIndexWithInputs :: FeatureSpec -> FeatureInputs -> [(Int, [Double], Double)]
+buildDatasetWithIndexWithInputs fs = buildDatasetWithIndexWithInputsWithMarket fs Nothing
+
+buildDatasetWithIndexWithInputsWithMarket :: FeatureSpec -> Maybe MarketModel -> FeatureInputs -> [(Int, [Double], Double)]
+buildDatasetWithIndexWithInputsWithMarket fs mMarket inputs =
+    let closes = fiClose inputs
+        n = V.length closes
         startT = fsLookbackBars fs - 1
         endT = n - 2
-        maxLag = max 1 (fsLookbackBars fs - 1)
-        shortB = min (fsShortBars fs) maxLag
-        midB = min (fsMidBars fs) maxLag
-        ret3Bars = min 3 maxLag
-        retLen = max 0 (n - 1)
-        returns =
-            V.generate retLen $ \i ->
-                let p0 = prices V.! i
-                    p1 = prices V.! (i + 1)
-                 in finiteReturn p0 p1
-        retRows = V.map retRow returns
-        retRow mRet =
-            case mRet of
-                Just r
-                    | isFiniteDouble r ->
-                        let r2 = r * r
-                         in if isFiniteDouble r2
-                                then (r, r2, 0 :: Int)
-                                else (0, 0, 1)
-                _ -> (0, 0, 1)
-        retVals = V.map (\(r, _, _) -> r) retRows
-        retSqVals = V.map (\(_, r2, _) -> r2) retRows
-        retInvalid = V.map (\(_, _, bad) -> bad) retRows
-        prefixSum = V.scanl' (+) 0 retVals
-        prefixSumSq = V.scanl' (+) 0 retSqVals
-        prefixInvalid = V.scanl' (+) 0 retInvalid
-
-        windowStats t k =
-            if k <= 0 || t - k < 0 || t - 1 >= retLen
-                then Nothing
-                else
-                    let i0 = t - k
-                        i1 = t - 1
-                        invalid = prefixInvalid V.! (i1 + 1) - prefixInvalid V.! i0
-                     in if invalid > 0
-                            then Nothing
-                            else
-                                let s = prefixSum V.! (i1 + 1) - prefixSum V.! i0
-                                    ss = prefixSumSq V.! (i1 + 1) - prefixSumSq V.! i0
-                                    k' = fromIntegral k
-                                    mu = s / k'
-                                    varRaw =
-                                        if k < 2
-                                            then 0
-                                            else (ss - k' * mu * mu) / fromIntegral (k - 1)
-                                    var = max 0 varRaw
-                                 in if all isFiniteDouble [s, ss, mu, var]
-                                        then Just (mu, sqrt (var + 1e-12))
-                                        else Nothing
-
-        windowReturns t k =
-            if k <= 0 || t - k < 0 || t - 1 >= retLen
-                then Nothing
-                else
-                    let i0 = t - k
-                        i1 = t - 1
-                        invalid = prefixInvalid V.! (i1 + 1) - prefixInvalid V.! i0
-                     in if invalid > 0
-                            then Nothing
-                            else Just [retVals V.! i | i <- [i0 .. i1]]
-
-        retOverFast t bars =
-            if bars <= 0 || t - bars < 0
-                then Nothing
-                else
-                    let p0 = prices V.! (t - bars)
-                        p1 = prices V.! t
-                     in finiteReturn p0 p1
-
-        featuresAtFast t = do
-            if t < fsLookbackBars fs - 1 || t >= n
-                then Nothing
-                else do
-                    ret1 <- retOverFast t 1
-                    ret3 <- retOverFast t ret3Bars
-                    retShort <- retOverFast t shortB
-                    retMid <- retOverFast t midB
-                    retLb <- retOverFast t (fsLookbackBars fs - 1)
-                    (muS, sigS) <- windowStats t shortB
-                    (muM, sigM) <- windowStats t midB
-                    rsShort <- windowReturns t shortB
-                    let priceT = prices V.! t
-                        psych = psychologicalFeatures priceT
-                        marketFeats = marketFeaturesFromModel mMarket t ret1 rsShort
-                        eps = 1e-12
-                        retSpread = retShort - retMid
-                        retMeanReversion = ret1 - muS
-                        volRatio = if abs sigM <= eps then 0 else sigS / sigM
-                        trendSlope = muS - muM
-                        feats =
-                            [ ret1
-                            , ret3
-                            , retShort
-                            , retMid
-                            , retLb
-                            , muS
-                            , sigS
-                            , muM
-                            , sigM
-                            , retSpread
-                            , retMeanReversion
-                            , volRatio
-                            , trendSlope
-                            ]
-                                ++ marketFeats
-                                ++ psych
-                    if all isFiniteDouble feats
-                        then pure feats
-                        else Nothing
-
-        forwardReturnFast t =
-            if t < 0 || t >= retLen
-                then Nothing
-                else returns V.! t
      in if startT > endT
             then []
             else
-                [ (t, f, y)
+                [ (t, feats, target)
                 | t <- [startT .. endT]
-                , Just f <- [featuresAtFast t]
-                , all isFiniteDouble f
-                , Just y <- [forwardReturnFast t]
-                , isFiniteDouble y
+                , Just feats <- [featuresAtWithInputsWithMarket fs mMarket inputs t]
+                , Just target <- [forwardReturnAt closes t]
+                , isFiniteDouble target
                 ]
 
 {- | Build a supervised dataset (features at t, target forward return at t).
 Uses t in [lookbackBars-1 .. n-2].
 -}
 buildDataset :: FeatureSpec -> V.Vector Double -> [([Double], Double)]
-buildDataset fs = buildDatasetWithMarket fs Nothing
+buildDataset fs = buildDatasetWithInputsWithMarket fs Nothing . featureInputsFromClose
 
 buildDatasetWithMarket :: FeatureSpec -> Maybe MarketModel -> V.Vector Double -> [([Double], Double)]
-buildDatasetWithMarket fs mMarket prices =
-    [(f, y) | (_, f, y) <- buildDatasetWithIndexWithMarket fs mMarket prices]
+buildDatasetWithMarket fs mMarket = buildDatasetWithInputsWithMarket fs mMarket . featureInputsFromClose
+
+buildDatasetWithInputs :: FeatureSpec -> FeatureInputs -> [([Double], Double)]
+buildDatasetWithInputs fs = buildDatasetWithInputsWithMarket fs Nothing
+
+buildDatasetWithInputsWithMarket :: FeatureSpec -> Maybe MarketModel -> FeatureInputs -> [([Double], Double)]
+buildDatasetWithInputsWithMarket fs mMarket inputs =
+    [(feats, target) | (_, feats, target) <- buildDatasetWithIndexWithInputsWithMarket fs mMarket inputs]
 
 retOver :: V.Vector Double -> Int -> Int -> Maybe Double
 retOver prices t bars =
@@ -266,6 +224,236 @@ returnsEndingAt prices t k =
                     ]
              in sequence rs
 
+barAt :: FeatureInputs -> Int -> Maybe Bar
+barAt inputs t
+    | t < 0 = Nothing
+    | t >= V.length closes = Nothing
+    | otherwise =
+        let closePx = closes V.! t
+         in if not (isFiniteDouble closePx)
+                then Nothing
+                else
+                    let prevClose =
+                            if t <= 0
+                                then closePx
+                                else closeOr closePx (t - 1)
+                        openPx =
+                            case validVectorValue (fiOpen inputs) t of
+                                Just v -> v
+                                Nothing -> prevClose
+                        highBase = max openPx closePx
+                        lowBase = min openPx closePx
+                        highPx =
+                            case validVectorValue (fiHigh inputs) t of
+                                Just v -> max highBase v
+                                Nothing -> highBase
+                        lowPx =
+                            case validVectorValue (fiLow inputs) t of
+                                Just v -> min lowBase v
+                                Nothing -> lowBase
+                        volumePx =
+                            case validVectorValue (fiVolume inputs) t of
+                                Just v | v >= 0 -> v
+                                _ -> 1
+                        bar =
+                            Bar
+                                { barOpen = openPx
+                                , barHigh = highPx
+                                , barLow = lowPx
+                                , barClose = closePx
+                                , barVolume = volumePx
+                                }
+                     in if all isFiniteDouble [openPx, highPx, lowPx, volumePx] && highPx >= lowPx
+                            then Just bar
+                            else Nothing
+  where
+    closes = fiClose inputs
+    closeOr fallback ix =
+        if ix < 0 || ix >= V.length closes
+            then fallback
+            else
+                let v = closes V.! ix
+                 in if isFiniteDouble v then v else fallback
+
+validVectorValue :: Maybe (V.Vector Double) -> Int -> Maybe Double
+validVectorValue mv ix = do
+    vec <- mv
+    if ix < 0 || ix >= V.length vec
+        then Nothing
+        else
+            let v = vec V.! ix
+             in if isFiniteDouble v then Just v else Nothing
+
+barsEndingAt :: FeatureInputs -> Int -> Int -> Maybe [Bar]
+barsEndingAt inputs endIx k
+    | k <= 0 = Nothing
+    | endIx < 0 = Nothing
+    | otherwise =
+        let startIx = endIx - k + 1
+         in if startIx < 0
+                then Nothing
+                else sequence [barAt inputs ix | ix <- [startIx .. endIx]]
+
+trueRangeAt :: FeatureInputs -> Int -> Maybe Double
+trueRangeAt inputs t = do
+    bar <- barAt inputs t
+    let closes = fiClose inputs
+        prevCloseRaw =
+            if t <= 0
+                then barClose bar
+                else closes V.! (t - 1)
+        prevClose =
+            if isFiniteDouble prevCloseRaw
+                then prevCloseRaw
+                else barClose bar
+        tr =
+            maximum
+                [ barHigh bar - barLow bar
+                , abs (barHigh bar - prevClose)
+                , abs (barLow bar - prevClose)
+                ]
+    if isFiniteDouble tr
+        then Just tr
+        else Nothing
+
+trueRangesEndingAt :: FeatureInputs -> Int -> Int -> Maybe [Double]
+trueRangesEndingAt inputs endIx k
+    | k <= 0 = Nothing
+    | endIx < 0 = Nothing
+    | otherwise =
+        let startIx = endIx - k + 1
+         in if startIx < 0
+                then Nothing
+                else sequence [trueRangeAt inputs ix | ix <- [startIx .. endIx]]
+
+klineFeatures :: FeatureInputs -> Bar -> Int -> Double -> Double -> Double -> [Double] -> [Double] -> Int -> Int -> [Double]
+klineFeatures inputs barNow t ret1 retShort retMid rsShort rsMid shortB midB =
+    let eps = 1e-12
+        currentClose = max eps (abs (barClose barNow))
+        currentRange = max 0 (barHigh barNow - barLow barNow)
+        upperWick = max 0 (barHigh barNow - max (barOpen barNow) (barClose barNow))
+        lowerWick = max 0 (min (barOpen barNow) (barClose barNow) - barLow barNow)
+        closeInRange =
+            if currentRange <= eps
+                then 0
+                else clamp (-1) 1 (2 * ((barClose barNow - barLow barNow) / currentRange) - 1)
+        bodyToRange =
+            if currentRange <= eps
+                then 0
+                else abs (barClose barNow - barOpen barNow) / currentRange
+        prevClose =
+            if t <= 0
+                then barClose barNow
+                else fiClose inputs V.! (t - 1)
+        gapRet =
+            case finiteReturn prevClose (barOpen barNow) of
+                Just v -> v
+                Nothing -> 0
+        barsShort = fromMaybeList [barNow] (barsEndingAt inputs t shortB)
+        barsMid = fromMaybeList barsShort (barsEndingAt inputs t midB)
+        barsShortPrev = fromMaybeList [] (barsEndingAt inputs (t - 1) shortB)
+        barsMidPrev = fromMaybeList barsShortPrev (barsEndingAt inputs (t - 1) midB)
+        trueShort = fromMaybeList [currentRange] (trueRangesEndingAt inputs t shortB)
+        trueMid = fromMaybeList trueShort (trueRangesEndingAt inputs t midB)
+        atrShort = meanList trueShort / currentClose
+        atrMid = meanList trueMid / currentClose
+        rangeRet = currentRange / currentClose
+        rangeToAtr =
+            if atrShort <= eps
+                then 0
+                else rangeRet / atrShort
+        recentHigh =
+            case map barHigh barsMidPrev of
+                [] -> barClose barNow
+                hs -> maximum hs
+        recentLow =
+            case map barLow barsMidPrev of
+                [] -> barClose barNow
+                ls -> minimum ls
+        recentMaxClose = max currentClose (maximum (map barClose barsMid))
+        recentMinClose = min (barClose barNow) (minimum (map barClose barsMid))
+        breakoutHigh =
+            if recentHigh <= eps
+                then 0
+                else barClose barNow / recentHigh - 1
+        breakoutLow =
+            if recentLow <= eps
+                then 0
+                else barClose barNow / recentLow - 1
+        closeDrawdown =
+            if recentMaxClose <= eps
+                then 0
+                else barClose barNow / recentMaxClose - 1
+        closeRebound =
+            if recentMinClose <= eps
+                then 0
+                else barClose barNow / recentMinClose - 1
+        volsShort = map barVolume barsShort
+        volsMid = map barVolume barsMid
+        (volMuS, volSigS) = meanStd volsShort
+        (volMuM, volSigM) = meanStd volsMid
+        volZShort =
+            if volSigS <= eps
+                then 0
+                else (barVolume barNow - volMuS) / volSigS
+        volZMid =
+            if volSigM <= eps
+                then 0
+                else (barVolume barNow - volMuM) / volSigM
+        prevVolume =
+            case barAt inputs (t - 1) of
+                Just prevBar -> barVolume prevBar
+                Nothing -> barVolume barNow
+        volMomentum =
+            if prevVolume <= eps
+                then 0
+                else barVolume barNow / prevVolume - 1
+        priceVolumePressure = ret1 * volZShort
+        efficiencyShort = efficiencyRatio retShort rsShort
+        efficiencyMid = efficiencyRatio retMid rsMid
+        feats =
+            [ safeSignedRatio (barClose barNow - barOpen barNow) (abs (barOpen barNow))
+            , rangeRet
+            , upperWick / currentClose
+            , lowerWick / currentClose
+            , closeInRange
+            , bodyToRange
+            , gapRet
+            , atrShort
+            , atrMid
+            , rangeToAtr
+            , breakoutHigh
+            , breakoutLow
+            , closeDrawdown
+            , closeRebound
+            , volZShort
+            , volZMid
+            , volMomentum
+            , priceVolumePressure
+            , efficiencyShort
+            , efficiencyMid
+            ]
+     in map sanitizeFinite feats
+
+efficiencyRatio :: Double -> [Double] -> Double
+efficiencyRatio netRet rs =
+    let denom = sum (map abs rs)
+     in if denom <= 1e-12
+            then 0
+            else abs netRet / denom
+
+fromMaybeList :: [a] -> Maybe [a] -> [a]
+fromMaybeList fallback mXs =
+    case mXs of
+        Just xs -> xs
+        Nothing -> fallback
+
+meanList :: [Double] -> Double
+meanList xs =
+    case xs of
+        [] -> 0
+        _ -> sum xs / fromIntegral (length xs)
+
 meanStd :: [Double] -> (Double, Double)
 meanStd xs =
     case xs of
@@ -280,6 +468,18 @@ meanStd xs =
                             let denom = fromIntegral (n - 1)
                              in sum (map (\v -> (v - mu) * (v - mu)) xs) / denom
              in (mu, sqrt (var + 1e-12))
+
+safeSignedRatio :: Double -> Double -> Double
+safeSignedRatio numer denom =
+    if denom <= 1e-12
+        then 0
+        else sanitizeFinite (numer / denom)
+
+sanitizeFinite :: Double -> Double
+sanitizeFinite x =
+    if isFiniteDouble x
+        then x
+        else 0
 
 marketFeatureCount :: Int
 marketFeatureCount = 8

--- a/haskell/app/Trader/Predictors/KNN.hs
+++ b/haskell/app/Trader/Predictors/KNN.hs
@@ -1,0 +1,202 @@
+module Trader.Predictors.KNN (
+    KNNModel (..),
+    trainKNN,
+    predictKNN,
+) where
+
+import Data.List (sortOn)
+
+data KNNModel = KNNModel
+    { kmK :: !Int
+    , kmFeatureDim :: !Int
+    , kmMeans :: ![Double]
+    , kmScales :: ![Double]
+    , kmExamples :: [([Double], Double)]
+    , kmSigmaBase :: !(Maybe Double)
+    }
+    deriving (Eq, Show)
+
+trainKNN :: Int -> Int -> [([Double], Double)] -> KNNModel
+trainKNN maxExamples requestedK dataset
+    | maxExamples <= 0 = emptyKNNModel
+    | requestedK <= 0 = emptyKNNModel
+    | null dataset = emptyKNNModel
+    | otherwise =
+        let ds0 = sanitizeDataset dataset
+            ds = evenlySample maxExamples ds0
+            featureDim = featureDimFromDataset ds
+         in if featureDim <= 0 || null ds
+                then emptyKNNModel
+                else
+                    let means = featureMeans featureDim ds
+                        scales = featureScales featureDim means ds
+                        examples =
+                            [ (normalizeVector means scales x, y)
+                            | (x, y) <- ds
+                            ]
+                        sigmaBase = sigmaFromTargets (map snd ds)
+                        k = min (length examples) (max 1 requestedK)
+                     in KNNModel
+                            { kmK = k
+                            , kmFeatureDim = featureDim
+                            , kmMeans = means
+                            , kmScales = scales
+                            , kmExamples = examples
+                            , kmSigmaBase = sigmaBase
+                            }
+
+predictKNN :: KNNModel -> [Double] -> (Double, Maybe Double)
+predictKNN model query =
+    let expected = kmFeatureDim model
+        queryOk = expected > 0 && length query == expected && all isFiniteDouble query
+        modelOk =
+            expected > 0
+                && kmK model > 0
+                && not (null (kmExamples model))
+                && length (kmMeans model) == expected
+                && length (kmScales model) == expected
+                && all isFiniteDouble (kmMeans model)
+                && all isFiniteDouble (kmScales model)
+                && all (\(x, y) -> length x == expected && all isFiniteDouble x && isFiniteDouble y) (kmExamples model)
+     in if not modelOk || not queryOk
+            then (0, kmSigmaBase model)
+            else
+                let qNorm = normalizeVector (kmMeans model) (kmScales model) query
+                    neighbors =
+                        take
+                            (kmK model)
+                            (sortOn fst [(squaredDistance qNorm xNorm, y) | (xNorm, y) <- kmExamples model])
+                    weights =
+                        [ let d = max 0 dist
+                           in 1 / (1e-6 + d)
+                        | (dist, _y) <- neighbors
+                        ]
+                    totalW = sum weights
+                 in if totalW <= 0 || not (isFiniteDouble totalW)
+                        then (0, kmSigmaBase model)
+                        else
+                            let weightedYs = zip weights (map snd neighbors)
+                                mu = sum [w * y | (w, y) <- weightedYs] / totalW
+                                var =
+                                    sum [w * (y - mu) * (y - mu) | (w, y) <- weightedYs]
+                                        / totalW
+                                sigma =
+                                    let s = sqrt (max 0 var + 1e-12)
+                                     in if isFiniteDouble s then Just s else kmSigmaBase model
+                             in if isFiniteDouble mu
+                                    then (mu, sigma <|> kmSigmaBase model)
+                                    else (0, kmSigmaBase model)
+  where
+    (<|>) left right =
+        case left of
+            Just _ -> left
+            Nothing -> right
+
+emptyKNNModel :: KNNModel
+emptyKNNModel =
+    KNNModel
+        { kmK = 0
+        , kmFeatureDim = 0
+        , kmMeans = []
+        , kmScales = []
+        , kmExamples = []
+        , kmSigmaBase = Nothing
+        }
+
+sanitizeDataset :: [([Double], Double)] -> [([Double], Double)]
+sanitizeDataset dataset =
+    let finiteRows =
+            [ (x, y)
+            | (x, y) <- dataset
+            , not (null x)
+            , all isFiniteDouble x
+            , isFiniteDouble y
+            ]
+     in case finiteRows of
+            [] -> []
+            ((x0, _) : _) ->
+                let featureDim = length x0
+                 in filter ((== featureDim) . length . fst) finiteRows
+
+featureDimFromDataset :: [([Double], Double)] -> Int
+featureDimFromDataset dataset =
+    case map (length . fst) dataset of
+        [] -> 0
+        d : ds
+            | d <= 0 -> 0
+            | any (/= d) ds -> 0
+            | otherwise -> d
+
+evenlySample :: Int -> [a] -> [a]
+evenlySample maxExamples xs
+    | maxExamples <= 0 = []
+    | length xs <= maxExamples = xs
+    | maxExamples == 1 =
+        case xs of
+            y : _ -> [y]
+            [] -> []
+    | otherwise =
+        let n = length xs
+            atIndex i =
+                let ix =
+                        floor
+                            ( fromIntegral i
+                                * fromIntegral (n - 1)
+                                / fromIntegral (maxExamples - 1)
+                            )
+                 in xs !! ix
+         in [atIndex i | i <- [0 .. maxExamples - 1]]
+
+featureMeans :: Int -> [([Double], Double)] -> [Double]
+featureMeans featureDim dataset =
+    [ mean [x !! j | (x, _y) <- dataset]
+    | j <- [0 .. featureDim - 1]
+    ]
+
+featureScales :: Int -> [Double] -> [([Double], Double)] -> [Double]
+featureScales featureDim means dataset =
+    [ let vals = [x !! j | (x, _y) <- dataset]
+          mu = means !! j
+          n = length vals
+          var =
+            if n < 2
+                then 0
+                else
+                    sum (map (\v -> (v - mu) * (v - mu)) vals)
+                        / fromIntegral (n - 1)
+          s = sqrt (max 0 var + 1e-12)
+       in if isFiniteDouble s && s > 1e-6 then s else 1
+    | j <- [0 .. featureDim - 1]
+    ]
+
+normalizeVector :: [Double] -> [Double] -> [Double] -> [Double]
+normalizeVector means scales xs =
+    zipWith3
+        (\mu s x -> if s <= 1e-12 then x - mu else (x - mu) / s)
+        means
+        scales
+        xs
+
+squaredDistance :: [Double] -> [Double] -> Double
+squaredDistance xs ys =
+    sum (zipWith (\x y -> let d = x - y in d * d) xs ys)
+
+sigmaFromTargets :: [Double] -> Maybe Double
+sigmaFromTargets ys =
+    case ys of
+        [] -> Nothing
+        [_] -> Just 1e-6
+        _ ->
+            let mu = mean ys
+                var = sum (map (\y -> (y - mu) * (y - mu)) ys) / fromIntegral (length ys - 1)
+                sigma = sqrt (max 0 var + 1e-12)
+             in if isFiniteDouble sigma then Just sigma else Nothing
+
+mean :: [Double] -> Double
+mean xs =
+    case xs of
+        [] -> 0
+        _ -> sum xs / fromIntegral (length xs)
+
+isFiniteDouble :: Double -> Bool
+isFiniteDouble x = not (isNaN x || isInfinite x)

--- a/haskell/app/Trader/Predictors/Types.hs
+++ b/haskell/app/Trader/Predictors/Types.hs
@@ -20,6 +20,8 @@ import qualified Data.Set as Set
 
 data SensorId
     = SensorGBT
+    | SensorKNN
+    | SensorDecisionTree
     | SensorTCN
     | SensorTransformer
     | SensorHMM
@@ -36,6 +38,8 @@ predictorCode :: SensorId -> String
 predictorCode sid =
     case sid of
         SensorGBT -> "gbdt"
+        SensorKNN -> "knn"
+        SensorDecisionTree -> "decision_tree"
         SensorTCN -> "tcn"
         SensorTransformer -> "transformer"
         SensorHMM -> "hmm"
@@ -65,6 +69,14 @@ predictorSetFromString raw =
             case tok of
                 "gbdt" -> Right SensorGBT
                 "gbt" -> Right SensorGBT
+                "knn" -> Right SensorKNN
+                "knearestneighbors" -> Right SensorKNN
+                "nearestneighbors" -> Right SensorKNN
+                "decisiontree" -> Right SensorDecisionTree
+                "decisiontrees" -> Right SensorDecisionTree
+                "tree" -> Right SensorDecisionTree
+                "trees" -> Right SensorDecisionTree
+                "dt" -> Right SensorDecisionTree
                 "tcn" -> Right SensorTCN
                 "transformer" -> Right SensorTransformer
                 "hmm" -> Right SensorHMM
@@ -81,14 +93,14 @@ predictorSetFromString raw =
                 Right _ -> False
             ]
      in if null lowered
-            then Left "Predictors list is empty (expected gbdt,tcn,transformer,hmm,quantile,conformal, all, none)."
+            then Left "Predictors list is empty (expected gbdt,knn,decision_tree,tcn,transformer,hmm,quantile,conformal, all, none)."
             else
                 if not (null bad)
                     then
                         Left
                             ( "Invalid predictors: "
                                 ++ intercalate ", " bad
-                                ++ " (expected gbdt,tcn,transformer,hmm,quantile,conformal, all, none)."
+                                ++ " (expected gbdt,knn,decision_tree,tcn,transformer,hmm,quantile,conformal, all, none)."
                             )
                     else
                         if hasAll && hasNone

--- a/haskell/app/Trader/SensorVariance.hs
+++ b/haskell/app/Trader/SensorVariance.hs
@@ -39,6 +39,10 @@ varianceEwma ev =
 data SensorVar = SensorVar
     { svGBT :: !Welford
     , svGBTEwma :: !EwmaVar
+    , svKNN :: !Welford
+    , svKNNEwma :: !EwmaVar
+    , svDecisionTree :: !Welford
+    , svDecisionTreeEwma :: !EwmaVar
     , svTCN :: !Welford
     , svTCNEwma :: !EwmaVar
     , svTransformer :: !Welford
@@ -57,6 +61,10 @@ emptySensorVar =
     SensorVar
         { svGBT = emptyWelford
         , svGBTEwma = emptyEwmaVar
+        , svKNN = emptyWelford
+        , svKNNEwma = emptyEwmaVar
+        , svDecisionTree = emptyWelford
+        , svDecisionTreeEwma = emptyEwmaVar
         , svTCN = emptyWelford
         , svTCNEwma = emptyEwmaVar
         , svTransformer = emptyWelford
@@ -78,6 +86,16 @@ updateResidual sid resid sv =
                 sv
                     { svGBT = updateWelford resid (svGBT sv)
                     , svGBTEwma = updateEwmaVar resid (svGBTEwma sv)
+                    }
+            SensorKNN ->
+                sv
+                    { svKNN = updateWelford resid (svKNN sv)
+                    , svKNNEwma = updateEwmaVar resid (svKNNEwma sv)
+                    }
+            SensorDecisionTree ->
+                sv
+                    { svDecisionTree = updateWelford resid (svDecisionTree sv)
+                    , svDecisionTreeEwma = updateEwmaVar resid (svDecisionTreeEwma sv)
                     }
             SensorTCN ->
                 sv
@@ -113,6 +131,8 @@ varianceFor sid sv =
                 Nothing -> varianceWelford welford >>= finiteNonNegative
      in case sid of
             SensorGBT -> preferEwma (svGBTEwma sv) (svGBT sv)
+            SensorKNN -> preferEwma (svKNNEwma sv) (svKNN sv)
+            SensorDecisionTree -> preferEwma (svDecisionTreeEwma sv) (svDecisionTree sv)
             SensorTCN -> preferEwma (svTCNEwma sv) (svTCN sv)
             SensorTransformer -> preferEwma (svTransformerEwma sv) (svTransformer sv)
             SensorHMM -> preferEwma (svHMMEwma sv) (svHMM sv)

--- a/haskell/test/TestMain.hs
+++ b/haskell/test/TestMain.hs
@@ -53,9 +53,11 @@ import Trader.OrderExecution (OrderExecutionEvidence (..), applyExecutedQuantity
 import Trader.Platform (Platform (..), coinbaseIntervalSeconds, isPlatformInterval, krakenIntervalMinutes, parsePlatform, poloniexIntervalLabel, poloniexIntervalSeconds)
 import Trader.Poloniex (PoloniexCandle (..), decodePoloniexCandles, normalizePoloniexCandles)
 import Trader.Predictors (Interval (..), Quantiles (..), RegimeProbs (..), SensorId (..), SensorOutput (..), initHMMFilter, predictSensors, trainPredictors)
-import Trader.Predictors.Features (buildDatasetWithIndex, featuresAt, featuresAtWithMarket, forwardReturnAt, mkFeatureSpec)
+import Trader.Predictors.DecisionTree (predictDecisionTree, trainDecisionTree)
+import Trader.Predictors.Features (buildDatasetWithIndex, featuresAt, featuresAtWithInputs, featuresAtWithMarket, forwardReturnAt, mkFeatureInputs, mkFeatureSpec)
+import Trader.Predictors.KNN (predictKNN, trainKNN)
 import Trader.Predictors.Transformer (TransformerModel (..), predictTransformer, trainTransformer)
-import Trader.Predictors.Types (allPredictors)
+import Trader.Predictors.Types (allPredictors, predictorSetFromString)
 import Trader.SensorVariance (emptySensorVar, updateResidual, varianceFor)
 import Trader.SignalGates (signalCrossAssetCheck, signalFundingOiCheck, signalMetaLabelOk, signalMtfConsensusCheck, signalRegimeEdgeOk, signalRunPostDirectionGates)
 import Trader.Split (Split (..), splitTrainBacktest)
@@ -80,10 +82,14 @@ main = do
               , run "kalman fusion multi-sensor" testKalmanFusionMulti
               , run "market linear fit" testMarketLinearFit
               , run "predictors output shape" testPredictorsOutputs
+              , run "predictor parser accepts knn and decision tree" testPredictorParserSupportsKnnAndDecisionTree
               , run "predictor features reject non-finite price inputs" testPredictorFeaturesRejectNonFinitePrices
               , run "predictor market features stay finite" testPredictorMarketFeaturesStayFinite
+              , run "predictor kline features use OHLCV context" testPredictorFeaturesUseOhlcvContext
               , run "predictor dataset skips non-finite rows" testBuildDatasetSkipsNonFiniteRows
               , run "predictor dataset skips overflowed finite feature rows" testBuildDatasetSkipsOverflowedFiniteRows
+              , run "knn predictor yields finite output" testKnnPredictorFinite
+              , run "decision tree predictor yields finite output" testDecisionTreePredictorFinite
               , run "transformer training skips invalid rows" testTransformerTrainingSanitizesDataset
               , run "transformer prediction rejects non-finite query" testTransformerPredictionRejectsNonFiniteQuery
               , run "transformer training normalizes invalid temperature" testTransformerInvalidTemperatureFallback
@@ -644,6 +650,8 @@ testPredictorsOutputs = do
         ids = map fst outs
 
     assert "has GBDT" (SensorGBT `elem` ids)
+    assert "has kNN" (SensorKNN `elem` ids)
+    assert "has decision tree" (SensorDecisionTree `elem` ids)
     assert "has TCN" (SensorTCN `elem` ids)
     assert "has Transformer" (SensorTransformer `elem` ids)
     assert "has HMM" (SensorHMM `elem` ids)
@@ -671,6 +679,19 @@ testPredictorsOutputs = do
                 Nothing -> error "missing interval"
                 Just (Interval lo hi) -> assert "interval ordered" (lo <= hi)
 
+testPredictorParserSupportsKnnAndDecisionTree :: IO ()
+testPredictorParserSupportsKnnAndDecisionTree = do
+    let parsed = predictorSetFromString "knn,decision_tree,tcn"
+        parsedAlias = predictorSetFromString "tree,gbdt"
+    case parsed of
+        Left err -> error ("expected predictor parser success: " ++ err)
+        Right preds -> do
+            assert "knn parsed" (SensorKNN `elem` preds)
+            assert "decision tree parsed" (SensorDecisionTree `elem` preds)
+    case parsedAlias of
+        Left err -> error ("expected predictor alias parser success: " ++ err)
+        Right preds -> assert "tree alias parsed" (SensorDecisionTree `elem` preds)
+
 testPredictorFeaturesRejectNonFinitePrices :: IO ()
 testPredictorFeaturesRejectNonFinitePrices = do
     let nan = 0 / 0
@@ -694,10 +715,32 @@ testPredictorMarketFeaturesStayFinite = do
     case featuresAtWithMarket fs (Just mm) prices 4 of
         Nothing -> error "missing market-aware features"
         Just feats -> do
-            assert "market-aware vector length expands with context features" (length feats == 33)
+            assert "market-aware vector length expands with context features" (length feats == 53)
             assert "market-aware feature rows remain finite" (all isFiniteDouble feats)
-            let marketSlice = take 8 (drop 13 feats)
+            let marketSlice = take 8 (drop 33 feats)
             assert "market-aware slice carries non-zero signal" (any (\x -> abs x > 1e-12) marketSlice)
+
+testPredictorFeaturesUseOhlcvContext :: IO ()
+testPredictorFeaturesUseOhlcvContext = do
+    let fs = mkFeatureSpec 4
+        closes = V.fromList [100.0, 101.0, 102.0, 101.5, 103.0, 104.0]
+        opens = V.fromList [99.5, 100.5, 101.0, 102.5, 101.8, 103.2]
+        highs = V.fromList [100.8, 101.9, 102.8, 103.1, 103.8, 104.7]
+        lows = V.fromList [99.1, 100.1, 100.7, 101.1, 101.2, 102.8]
+        volumes = V.fromList [12.0, 11.5, 18.0, 8.0, 22.0, 25.0]
+        richInputs = mkFeatureInputs closes (Just opens) (Just highs) (Just lows) (Just volumes)
+        flatInputs = mkFeatureInputs closes Nothing Nothing Nothing Nothing
+    case (featuresAt fs closes 4, featuresAtWithMarket fs Nothing closes 4) of
+        (Just closeOnly, Just marketWrapped) ->
+            assert "legacy close-only wrappers stay aligned" (closeOnly == marketWrapped)
+        _ -> error "expected legacy features from close-only wrappers"
+    case (featuresAtWithInputs fs richInputs 4, featuresAtWithInputs fs flatInputs 4) of
+        (Nothing, _) -> error "missing OHLCV-aware features"
+        (_, Nothing) -> error "missing fallback features"
+        (Just rich, Just flat) -> do
+            assert "OHLCV-aware features keep stable dimension" (length rich == length flat && length rich == 53)
+            assert "OHLCV-aware features remain finite" (all isFiniteDouble rich)
+            assert "OHLCV context changes the feature vector" (rich /= flat)
 
 testBuildDatasetSkipsNonFiniteRows :: IO ()
 testBuildDatasetSkipsNonFiniteRows = do
@@ -721,6 +764,28 @@ testBuildDatasetSkipsOverflowedFiniteRows = do
     assert "featuresAt rejects overflowed variance window with non-finite stats" (isNothing (featuresAt fs prices 2))
     assert "dataset keeps only stable rows after overflowed-return window" (indices == [3])
     assert "dataset rows remain finite after overflow guard" allFiniteRows
+
+testKnnPredictorFinite :: IO ()
+testKnnPredictorFinite = do
+    let dataset =
+            [ ([x, x * x], 0.5 * x - 0.1)
+            | x <- [-1.0, -0.5, 0.0, 0.5, 1.0, 1.5]
+            ]
+        model = trainKNN 32 3 dataset
+        (mu, mSigma) = predictKNN model [0.25, 0.0625]
+    assert "knn mean stays finite" (isFiniteDouble mu)
+    assert "knn sigma stays finite" (maybe False isFiniteDouble mSigma)
+
+testDecisionTreePredictorFinite :: IO ()
+testDecisionTreePredictorFinite = do
+    let dataset =
+            [ ([x, x * x], if x >= 0 then 0.02 + x else -0.02 + x)
+            | x <- [-2.0, -1.0, -0.5, 0.0, 0.5, 1.0, 2.0]
+            ]
+        model = trainDecisionTree 4 2 dataset
+        (mu, mSigma) = predictDecisionTree model [0.75, 0.5625]
+    assert "decision tree mean stays finite" (isFiniteDouble mu)
+    assert "decision tree sigma stays finite" (maybe False isFiniteDouble mSigma)
 
 testTransformerTrainingSanitizesDataset :: IO ()
 testTransformerTrainingSanitizesDataset = do

--- a/haskell/trader.cabal
+++ b/haskell/trader.cabal
@@ -48,6 +48,8 @@ executable trader-hs
                      , Trader.Predictors
                      , Trader.Predictors.Types
                      , Trader.Predictors.Features
+                     , Trader.Predictors.KNN
+                     , Trader.Predictors.DecisionTree
                      , Trader.Predictors.GBDT
                      , Trader.Predictors.TCN
                      , Trader.Predictors.Transformer
@@ -213,6 +215,8 @@ test-suite trader-tests
                      , Trader.Predictors
                      , Trader.Predictors.Types
                      , Trader.Predictors.Features
+                     , Trader.Predictors.KNN
+                     , Trader.Predictors.DecisionTree
                      , Trader.Predictors.GBDT
                      , Trader.Predictors.TCN
                      , Trader.Predictors.Transformer

--- a/haskell/web/src/App.tsx
+++ b/haskell/web/src/App.tsx
@@ -258,6 +258,7 @@ import {
   roundRatioDown,
   roundRatioUp,
   safeJsonParse,
+  sanitizeSymbolForPlatform,
   sanitizeFilenameSegment,
   sigBool,
   sigNumber,
@@ -1449,7 +1450,7 @@ export function App() {
   const normalizedSymbol = form.binanceSymbol.trim().toUpperCase();
   const symbolFormatError = useMemo(() => {
     if (!normalizedSymbol) return null;
-    return symbolFormatPattern(platform).test(normalizedSymbol)
+    return sanitizeSymbolForPlatform(platform, normalizedSymbol)
       ? null
       : `Symbol must match ${platformLabel} format (e.g., ${symbolFormatExample(platform)}).`;
   }, [normalizedSymbol, platform, platformLabel]);
@@ -3822,7 +3823,7 @@ export function App() {
 
   const tradeParams: ApiParams = useMemo(() => {
     const base: ApiParams = { ...commonParams };
-    if (form.platform === "binance" && form.binanceLive) base.binanceLive = true;
+    if ((form.platform === "binance" || form.platform === "coinbase") && form.binanceLive) base.binanceLive = true;
     const k = form.idempotencyKey.trim();
     const idOk = !k || (k.length <= 36 && /^[A-Za-z0-9_-]+$/.test(k));
     if (k && idOk) base.idempotencyKey = k;
@@ -7505,6 +7506,9 @@ export function App() {
     if (!isBinancePlatform && !isCoinbasePlatform) {
       return { message: "Trading is supported on Binance and Coinbase only.", targetId: "platform" };
     }
+    if (isCoinbasePlatform && !form.binanceLive) {
+      return { message: "Coinbase does not support test orders. Enable Live orders.", targetId: "section-trade" };
+    }
     if (isCoinbasePlatform && form.positioning === "long-short") {
       return { message: "Coinbase supports spot only (positioning=long-flat).", targetId: "positioning" };
     }
@@ -7516,6 +7520,7 @@ export function App() {
     }
     return null;
   }, [
+    form.binanceLive,
     form.market,
     form.positioning,
     isBinancePlatform,

--- a/haskell/web/src/app/appHelpers.ts
+++ b/haskell/web/src/app/appHelpers.ts
@@ -27,6 +27,16 @@ import type { FormState } from "./formState";
 import type { cacheStats, health } from "../lib/api";
 import { PLATFORM_DEFAULT_SYMBOL } from "./constants";
 import { METHOD_TIPS } from "./methodMeta";
+import {
+  BINANCE_SYMBOL_PATTERN,
+  COMMON_QUOTES,
+  invalidSymbolsForPlatform,
+  normalizeComboSymbol,
+  sanitizeSymbolForPlatform,
+  symbolFormatExample,
+  symbolFormatPattern,
+  trimBinanceComboSuffix,
+} from "./symbols";
 import { clamp, normalizePositionSide, normalizeSymbolKey, numFromInput, positionSideFromAmount } from "./utils";
 
 export type RequestKind = "signal" | "backtest" | "trade";
@@ -198,22 +208,16 @@ export function parseSymbolsInput(raw: string): string[] {
   }
   return out;
 }
-
-export function symbolFormatPattern(platform: Platform): RegExp {
-  switch (platform) {
-    case "coinbase":
-      return /^[A-Z0-9]+-[A-Z0-9]+$/;
-    case "poloniex":
-      return /^[A-Z0-9]+_[A-Z0-9]+$/;
-    case "binance":
-    case "kraken":
-    default:
-      return /^[A-Z0-9]{3,30}$/;
-  }
-}
-
-export const COMMON_QUOTES = ["USDT", "USDC", "FDUSD", "TUSD", "BUSD", "BTC", "ETH", "BNB"];
-export const BINANCE_SYMBOL_PATTERN = /^[A-Z0-9]{3,30}$/;
+export {
+  BINANCE_SYMBOL_PATTERN,
+  COMMON_QUOTES,
+  invalidSymbolsForPlatform,
+  normalizeComboSymbol,
+  sanitizeSymbolForPlatform,
+  symbolFormatExample,
+  symbolFormatPattern,
+  trimBinanceComboSuffix,
+};
 export const EQUITY_TIPS = {
   preset: [
     'Use "Preset: Equity focus", then bump Trials/Timeout to widen the search.',
@@ -250,92 +254,6 @@ export const COMPLEX_TIPS = {
     "Embargo bars drop samples near fold edges to reduce leakage.",
   ],
 };
-
-export function trimBinanceComboSuffix(value: string): string | null {
-  const compact = value.replace(/[^A-Z0-9]/g, "");
-  if (!compact) return null;
-  let best: string | null = null;
-  for (const quote of COMMON_QUOTES) {
-    let idx = compact.indexOf(quote);
-    while (idx >= 0) {
-      const end = idx + quote.length;
-      if (end < compact.length) {
-        const suffix = compact.slice(end);
-        if (/\d/.test(suffix)) {
-          const candidate = compact.slice(0, end);
-          if (BINANCE_SYMBOL_PATTERN.test(candidate) && !COMMON_QUOTES.includes(candidate)) {
-            if (!best || candidate.length > best.length) best = candidate;
-          }
-        }
-      }
-      idx = compact.indexOf(quote, idx + 1);
-    }
-  }
-  return best;
-}
-
-export function normalizeComboSymbol(raw: string, platform: Platform | null): string {
-  const value = raw.trim().toUpperCase();
-  if (!value) return value;
-  const resolvedPlatform: Platform = platform ?? "binance";
-  const pattern = symbolFormatPattern(resolvedPlatform);
-  const isBinanceLike = resolvedPlatform === "binance" || resolvedPlatform === "kraken";
-
-  if (isBinanceLike) {
-    const trimmed = trimBinanceComboSuffix(value);
-    if (trimmed) return trimmed;
-  }
-
-  if (pattern.test(value)) return value;
-
-  if (resolvedPlatform === "coinbase") {
-    const parts = value.split("-");
-    if (parts.length >= 2) {
-      const candidate = `${parts[0]}-${parts[1]}`;
-      if (pattern.test(candidate)) return candidate;
-    }
-    return value;
-  }
-
-  if (resolvedPlatform === "poloniex") {
-    const parts = value.split("_");
-    if (parts.length >= 2) {
-      const candidate = `${parts[0]}_${parts[1]}`;
-      if (pattern.test(candidate)) return candidate;
-    }
-    return value;
-  }
-
-  if (isBinanceLike) {
-    const tokens = value.split(/[^A-Z0-9]+/).filter(Boolean);
-    if (tokens.length >= 2) {
-      const joined = `${tokens[0]}${tokens[1]}`;
-      if (tokens.length === 2 && pattern.test(joined)) return joined;
-      if (tokens.length >= 3 && /^[0-9]+[A-Z]$/.test(tokens[2] ?? "") && pattern.test(joined)) return joined;
-    }
-    if (tokens.length >= 1 && pattern.test(tokens[0] ?? "")) return tokens[0] ?? value;
-  }
-  return value;
-}
-
-export function symbolFormatExample(platform: Platform): string {
-  switch (platform) {
-    case "coinbase":
-      return "BTC-USD";
-    case "poloniex":
-      return "BTC_USDT";
-    case "kraken":
-      return "XBTUSD";
-    case "binance":
-    default:
-      return "BTCUSDT";
-  }
-}
-
-export function invalidSymbolsForPlatform(platform: Platform, symbols: string[]): string[] {
-  const pattern = symbolFormatPattern(platform);
-  return symbols.filter((sym) => !pattern.test(sym));
-}
 
 export function parseMaybeInt(raw: string): number | null {
   const trimmed = raw.trim();
@@ -1515,7 +1433,7 @@ export function optimizerSourceForPlatform(platform: Platform): OptimizerSource 
 export function buildDefaultOptimizerRunForm(symbol: string, platform: Platform): OptimizerRunForm {
   return {
     source: optimizerSourceForPlatform(platform),
-    symbol: symbol.trim().toUpperCase(),
+    symbol: sanitizeSymbolForPlatform(platform, symbol) ?? symbol.trim().toUpperCase(),
     dataPath: "",
     priceColumn: "close",
     highColumn: "",
@@ -1583,8 +1501,8 @@ export function buildDefaultOptimizerRunForm(symbol: string, platform: Platform)
     edgeBufferMax: "",
     trendLookbackMin: "",
     trendLookbackMax: "",
-    rebalanceCostMultMin: "1",
-    rebalanceCostMultMax: "1",
+    rebalanceCostMultMin: "",
+    rebalanceCostMultMax: "",
     pCostAwareEdge: "",
     stopMin: "",
     stopMax: "",
@@ -2201,13 +2119,12 @@ export function applyComboToForm(
 ): FormState {
   const nextPlatform = combo.params.platform ?? prev.platform;
   const comboSymbolRaw = combo.params.binanceSymbol?.trim() ?? "";
-  const normalizedComboSymbol = comboSymbolRaw ? normalizeComboSymbol(comboSymbolRaw, nextPlatform) : "";
-  const comboSymbol =
-    normalizedComboSymbol && symbolFormatPattern(nextPlatform).test(normalizedComboSymbol) ? normalizedComboSymbol : "";
-  const prevSymbol = prev.binanceSymbol.trim().toUpperCase();
-  const prevSymbolValid = symbolFormatPattern(nextPlatform).test(prevSymbol);
-  const fallbackSymbol = PLATFORM_DEFAULT_SYMBOL[nextPlatform] ?? prev.binanceSymbol;
-  const symbol = comboSymbol || (prevSymbolValid ? prevSymbol : fallbackSymbol);
+  const comboSymbol = comboSymbolRaw ? sanitizeSymbolForPlatform(nextPlatform, comboSymbolRaw) : null;
+  const prevSymbol = sanitizeSymbolForPlatform(nextPlatform, prev.binanceSymbol);
+  const fallbackSymbol =
+    sanitizeSymbolForPlatform(nextPlatform, PLATFORM_DEFAULT_SYMBOL[nextPlatform] ?? prev.binanceSymbol)
+    ?? (PLATFORM_DEFAULT_SYMBOL[nextPlatform] ?? prev.binanceSymbol);
+  const symbol = comboSymbol ?? prevSymbol ?? fallbackSymbol;
   const interval = combo.params.interval;
   const method = manualOverrides?.has("method") ? prev.method : combo.params.method;
   const comboPositioning = combo.params.positioning ?? prev.positioning;

--- a/haskell/web/src/app/contracts.ts
+++ b/haskell/web/src/app/contracts.ts
@@ -33,6 +33,7 @@ export const METHOD_IDS = [
   "regime_switch",
   "router",
   "bandit_router",
+  "kalman_physics_error",
 ] as const;
 
 export type Method = (typeof METHOD_IDS)[number];

--- a/haskell/web/src/app/formState.ts
+++ b/haskell/web/src/app/formState.ts
@@ -1,5 +1,6 @@
 import type { IntrabarFill, Market, Method, Normalization, Platform, Positioning } from "../lib/types";
 import { BINANCE_INTERVAL_SECONDS, PLATFORM_DEFAULT_SYMBOL, PLATFORM_INTERVAL_SET, TUNE_OBJECTIVE_SET } from "./constants";
+import { sanitizeSymbolForPlatform } from "./symbols";
 import { clamp } from "./utils";
 
 export type FormState = {
@@ -148,7 +149,7 @@ export const defaultForm: FormState = {
   maxVolatility: 1.5,
   rebalanceBars: 24,
   rebalanceThreshold: 0.05,
-  rebalanceCostMult: 1,
+  rebalanceCostMult: 0,
   rebalanceGlobal: false,
   rebalanceResetOnSignal: false,
   fundingRate: 0.1,
@@ -227,23 +228,9 @@ export function platformIntervalSeconds(platform: Platform, interval: string): n
   return parseDurationSeconds(interval);
 }
 
-function symbolFormatPattern(platform: Platform): RegExp {
-  switch (platform) {
-    case "coinbase":
-      return /^[A-Z0-9]+-[A-Z0-9]+$/;
-    case "poloniex":
-      return /^[A-Z0-9]+_[A-Z0-9]+$/;
-    case "binance":
-    case "kraken":
-    default:
-      return /^[A-Z0-9]{3,30}$/;
-  }
-}
-
 function normalizeSymbol(raw: unknown, platform: Platform, fallback: string): string {
-  const s = typeof raw === "string" ? raw.trim().toUpperCase() : "";
-  if (!s) return fallback;
-  return symbolFormatPattern(platform).test(s) ? s : fallback;
+  const s = typeof raw === "string" ? raw : "";
+  return sanitizeSymbolForPlatform(platform, s) ?? fallback;
 }
 
 export function parseDurationSeconds(raw: string): number | null {
@@ -366,11 +353,12 @@ export function normalizeFormState(raw: FormStateJson | null | undefined): FormS
   const kalmanZMax = Math.max(kalmanZMin, kalmanZMaxRaw);
   const platform = normalizePlatform(rawRec.platform ?? merged.platform, defaultForm.platform);
   let market = platform === "binance" ? normalizeMarket(rawRec.market ?? merged.market, defaultForm.market) : "spot";
+  const liveOrdersSupported = platform === "binance" || platform === "coinbase";
   const binanceLiveCandidate =
-    platform === "binance" ? normalizeBool(rawRec.binanceLive ?? merged.binanceLive, defaultForm.binanceLive) : false;
+    liveOrdersSupported ? normalizeBool(rawRec.binanceLive ?? merged.binanceLive, defaultForm.binanceLive) : false;
   // Margin requires live orders; prefer a safe fallback over implicitly enabling live mode.
-  const binanceLive = market === "margin" && !binanceLiveCandidate ? false : binanceLiveCandidate;
-  if (market === "margin" && !binanceLiveCandidate) market = "spot";
+  const binanceLive = platform === "binance" && market === "margin" && !binanceLiveCandidate ? false : binanceLiveCandidate;
+  if (platform === "binance" && market === "margin" && !binanceLiveCandidate) market = "spot";
   // Trade arming is meaningful for Binance + Coinbase; disable it for non-trading platforms.
   const tradeArmed =
     platform === "binance" || platform === "coinbase"
@@ -380,8 +368,20 @@ export function normalizeFormState(raw: FormStateJson | null | undefined): FormS
     platform === "binance" && market !== "margin"
       ? normalizeBool(rawRec.binanceTestnet ?? merged.binanceTestnet, defaultForm.binanceTestnet)
       : false;
-  const symbolFallback = PLATFORM_DEFAULT_SYMBOL[platform] ?? defaultForm.binanceSymbol;
+  const symbolFallback =
+    sanitizeSymbolForPlatform(platform, PLATFORM_DEFAULT_SYMBOL[platform] ?? defaultForm.binanceSymbol)
+    ?? defaultForm.binanceSymbol;
   const binanceSymbol = normalizeSymbol(rawRec.binanceSymbol ?? merged.binanceSymbol, platform, symbolFallback);
+  // Keep restored manual sizing fields numeric before the sizing UI computes badges, cap state, and trade readiness.
+  const orderQuote = normalizeFiniteNumber(rawRec.orderQuote ?? merged.orderQuote, defaultForm.orderQuote, 0, 1e9);
+  const orderQuantity = normalizeFiniteNumber(rawRec.orderQuantity ?? merged.orderQuantity, defaultForm.orderQuantity, 0, 1e9);
+  const orderQuoteFraction = normalizeFiniteNumber(
+    rawRec.orderQuoteFraction ?? merged.orderQuoteFraction,
+    defaultForm.orderQuoteFraction,
+    -1e9,
+    1e9,
+  );
+  const maxOrderQuote = normalizeFiniteNumber(rawRec.maxOrderQuote ?? merged.maxOrderQuote, defaultForm.maxOrderQuote, 0, 1e9);
   const { threshold: _ignoredThreshold, ...mergedNoLegacy } = merged as FormState & { threshold?: unknown };
   return {
     ...mergedNoLegacy,
@@ -501,6 +501,10 @@ export function normalizeFormState(raw: FormStateJson | null | undefined): FormS
     patience: normalizeFiniteNumber(rawRec.patience ?? merged.patience, defaultForm.patience, 0, 100),
     gradClip: normalizeFiniteNumber(rawRec.gradClip ?? merged.gradClip, defaultForm.gradClip, 0, 10),
     minPositionSize: normalizeFiniteNumber(rawRec.minPositionSize ?? merged.minPositionSize, defaultForm.minPositionSize, 0, 1),
+    orderQuote,
+    orderQuantity,
+    orderQuoteFraction,
+    maxOrderQuote,
     botProtectionOrders: normalizeBool(rawRec.botProtectionOrders ?? merged.botProtectionOrders, defaultForm.botProtectionOrders),
     botAdoptExistingPosition: true,
   };

--- a/haskell/web/src/app/methodMeta.ts
+++ b/haskell/web/src/app/methodMeta.ts
@@ -220,6 +220,13 @@ export const METHOD_UI_META = [
     tip: "10 uses Kalman-only predictions.",
   },
   {
+    id: "kalman_physics_error",
+    optionTitle: "Kalman physics error",
+    label: "Kalman physics error",
+    configHint: "uses the Kalman state plus physics-error model.",
+    tip: "kalman_physics_error uses the Kalman state plus a physics-error model over the latest 1000 bars.",
+  },
+  {
     id: "01",
     optionTitle: "LSTM only",
     label: "LSTM only",

--- a/haskell/web/src/app/symbols.ts
+++ b/haskell/web/src/app/symbols.ts
@@ -1,0 +1,124 @@
+import type { Platform } from "../lib/types";
+
+export const COMMON_QUOTES = ["USDT", "USDC", "FDUSD", "TUSD", "BUSD", "BTC", "ETH", "BNB"];
+export const BINANCE_SYMBOL_PATTERN = /^[A-Z0-9]{3,30}$/;
+
+function normalizeSymbolText(raw: string): string {
+  return raw.trim().toUpperCase();
+}
+
+function splitAlphaNumTokens(raw: string): string[] {
+  return normalizeSymbolText(raw).split(/[^A-Z0-9]+/).filter(Boolean);
+}
+
+function delimitedSymbolPattern(delim: "-" | "_"): RegExp {
+  return delim === "-" ? /^[A-Z0-9]+-[A-Z0-9]+$/ : /^[A-Z0-9]+_[A-Z0-9]+$/;
+}
+
+function sanitizeDelimitedSymbol(raw: string, delim: "-" | "_"): string | null {
+  const value = normalizeSymbolText(raw);
+  if (!value) return null;
+
+  const pattern = delimitedSymbolPattern(delim);
+  if (pattern.test(value)) return value;
+
+  const replaced = value.replace(/[-_/]/g, delim);
+  if (pattern.test(replaced)) return replaced;
+
+  const tokens = splitAlphaNumTokens(replaced);
+  if (tokens.length !== 2) return null;
+  const candidate = `${tokens[0]}${delim}${tokens[1]}`;
+  return pattern.test(candidate) ? candidate : null;
+}
+
+export function trimBinanceComboSuffix(value: string): string | null {
+  const compact = value.replace(/[^A-Z0-9]/g, "");
+  if (!compact) return null;
+  let best: string | null = null;
+  for (const quote of COMMON_QUOTES) {
+    let idx = compact.indexOf(quote);
+    while (idx >= 0) {
+      const end = idx + quote.length;
+      if (end < compact.length) {
+        const suffix = compact.slice(end);
+        if (/\d/.test(suffix)) {
+          const candidate = compact.slice(0, end);
+          if (BINANCE_SYMBOL_PATTERN.test(candidate) && !COMMON_QUOTES.includes(candidate)) {
+            if (!best || candidate.length > best.length) best = candidate;
+          }
+        }
+      }
+      idx = compact.indexOf(quote, idx + 1);
+    }
+  }
+  return best;
+}
+
+function sanitizeBinanceLikeSymbol(raw: string): string | null {
+  const value = normalizeSymbolText(raw);
+  if (!value) return null;
+  if (BINANCE_SYMBOL_PATTERN.test(value)) return value;
+
+  const trimmed = trimBinanceComboSuffix(value);
+  if (trimmed) return trimmed;
+
+  const tokens = splitAlphaNumTokens(value);
+  if (tokens.length >= 2) {
+    const joined = `${tokens[0]}${tokens[1]}`;
+    if (tokens.length === 2 && BINANCE_SYMBOL_PATTERN.test(joined)) return joined;
+    if (tokens.length >= 3 && /^[0-9]+[A-Z]$/.test(tokens[2] ?? "") && BINANCE_SYMBOL_PATTERN.test(joined)) return joined;
+  }
+  if (tokens.length >= 1 && BINANCE_SYMBOL_PATTERN.test(tokens[0] ?? "")) return tokens[0] ?? null;
+  return null;
+}
+
+export function symbolFormatPattern(platform: Platform): RegExp {
+  switch (platform) {
+    case "coinbase":
+      return /^[A-Z0-9]+-[A-Z0-9]+$/;
+    case "poloniex":
+      return /^[A-Z0-9]+_[A-Z0-9]+$/;
+    case "binance":
+    case "kraken":
+    default:
+      return BINANCE_SYMBOL_PATTERN;
+  }
+}
+
+export function sanitizeSymbolForPlatform(platform: Platform, raw: string): string | null {
+  switch (platform) {
+    case "coinbase":
+      return sanitizeDelimitedSymbol(raw, "-");
+    case "poloniex":
+      return sanitizeDelimitedSymbol(raw, "_");
+    case "binance":
+    case "kraken":
+    default:
+      return sanitizeBinanceLikeSymbol(raw);
+  }
+}
+
+export function normalizeComboSymbol(raw: string, platform: Platform | null): string {
+  const value = normalizeSymbolText(raw);
+  if (!value) return value;
+  const resolvedPlatform: Platform = platform ?? "binance";
+  return sanitizeSymbolForPlatform(resolvedPlatform, value) ?? value;
+}
+
+export function symbolFormatExample(platform: Platform): string {
+  switch (platform) {
+    case "coinbase":
+      return "BTC-USD";
+    case "poloniex":
+      return "BTC_USDT";
+    case "kraken":
+      return "XBTUSD";
+    case "binance":
+    default:
+      return "BTCUSDT";
+  }
+}
+
+export function invalidSymbolsForPlatform(platform: Platform, symbols: string[]): string[] {
+  return symbols.filter((sym) => sanitizeSymbolForPlatform(platform, sym) == null);
+}

--- a/haskell/web/src/components/ConfigDock.tsx
+++ b/haskell/web/src/components/ConfigDock.tsx
@@ -21,8 +21,8 @@ import { fmtPct } from "../lib/format";
 import { API_PORT } from "../app/apiTarget";
 import { defaultForm, type FormState } from "../app/formState";
 import { firstReason, fmtTimeMs, generateIdempotencyKey, numFromInput } from "../app/utils";
-import { COMPLEX_TIPS, CUSTOM_SYMBOL_VALUE, EQUITY_TIPS } from "../app/appHelpers";
-import { PLATFORM_DEFAULT_SYMBOL, PLATFORM_LABELS, PLATFORM_SYMBOL_SET, PLATFORMS, TUNE_OBJECTIVES } from "../app/constants";
+import { COMPLEX_TIPS, CUSTOM_SYMBOL_VALUE, EQUITY_TIPS, sanitizeSymbolForPlatform } from "../app/appHelpers";
+import { PLATFORM_DEFAULT_SYMBOL, PLATFORM_LABELS, PLATFORMS, TUNE_OBJECTIVES } from "../app/constants";
 import { METHOD_CONFIG_HINT, METHOD_UI_META } from "../app/methodMeta";
 import { CollapsibleCard } from "./CollapsibleCard";
 import { InfoList, InfoPopover } from "./InfoPopover";
@@ -1010,10 +1010,10 @@ export const ConfigDock = (props: ConfigDockProps) => {
               setPendingMarket(null);
               setPendingProfileLoad(null);
               setForm((f) => {
-                const symbolSet = PLATFORM_SYMBOL_SET[next];
-                const fallback = customSymbolByPlatform[next] || PLATFORM_DEFAULT_SYMBOL[next];
-                const normalized = f.binanceSymbol.trim().toUpperCase();
-                const nextSymbol = symbolSet.has(normalized) ? normalized : fallback;
+                const fallback =
+                  sanitizeSymbolForPlatform(next, customSymbolByPlatform[next] || PLATFORM_DEFAULT_SYMBOL[next])
+                  ?? PLATFORM_DEFAULT_SYMBOL[next];
+                const nextSymbol = sanitizeSymbolForPlatform(next, f.binanceSymbol) ?? fallback;
                 if (next === "binance") return { ...f, platform: next, binanceSymbol: nextSymbol };
                 return {
                   ...f,
@@ -1070,7 +1070,8 @@ export const ConfigDock = (props: ConfigDockProps) => {
               className={missingSymbol || Boolean(symbolFormatError) ? "input inputError" : "input"}
               value={form.binanceSymbol}
               onChange={(e) => {
-                const next = e.target.value.toUpperCase();
+                const nextRaw = e.target.value;
+                const next = sanitizeSymbolForPlatform(platform, nextRaw) ?? nextRaw.toUpperCase();
                 setCustomSymbolByPlatform((prev) => ({ ...prev, [platform]: next }));
                 setForm((f) => ({ ...f, binanceSymbol: next }));
               }}

--- a/haskell/web/test/formSymbolBehavior.test.mjs
+++ b/haskell/web/test/formSymbolBehavior.test.mjs
@@ -1,0 +1,62 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { applyComboToForm, buildDefaultOptimizerRunForm, invalidSymbolsForPlatform, sanitizeSymbolForPlatform } from "../.tmp/web-tests/appHelpers.js";
+import { defaultForm, normalizeFormState } from "../.tmp/web-tests/formState.js";
+import { methodLabel } from "../.tmp/web-tests/utils.js";
+
+test("normalizeFormState canonicalizes slash-delimited symbols per platform", () => {
+  assert.equal(normalizeFormState({ platform: "binance", binanceSymbol: "eth/usdt" }).binanceSymbol, "ETHUSDT");
+  assert.equal(normalizeFormState({ platform: "coinbase", binanceSymbol: "eth/usd" }).binanceSymbol, "ETH-USD");
+  assert.equal(normalizeFormState({ platform: "poloniex", binanceSymbol: "eth/usdt" }).binanceSymbol, "ETH_USDT");
+});
+
+test("frontend symbol validation accepts backend-compatible aliases", () => {
+  assert.equal(sanitizeSymbolForPlatform("binance", "ETH/USDT"), "ETHUSDT");
+  assert.equal(sanitizeSymbolForPlatform("coinbase", "ETH/USD"), "ETH-USD");
+  assert.equal(sanitizeSymbolForPlatform("poloniex", "ETH-USDT"), "ETH_USDT");
+  assert.deepEqual(invalidSymbolsForPlatform("coinbase", ["ETH/USD", "BTC-USD"]), []);
+});
+
+test("applyComboToForm keeps valid slash-delimited combo symbols instead of falling back", () => {
+  const combo = {
+    id: 7,
+    openThreshold: defaultForm.openThreshold,
+    closeThreshold: defaultForm.closeThreshold,
+    params: {
+      platform: "coinbase",
+      binanceSymbol: "ETH/USD",
+      interval: defaultForm.interval,
+      method: defaultForm.method,
+      positioning: defaultForm.positioning,
+      normalization: defaultForm.normalization,
+      fee: defaultForm.fee,
+      epochs: defaultForm.epochs,
+      hiddenSize: defaultForm.hiddenSize,
+    },
+  };
+  const next = applyComboToForm(defaultForm, combo, null);
+  assert.equal(next.platform, "coinbase");
+  assert.equal(next.binanceSymbol, "ETH-USD");
+});
+
+test("coinbase restores keep live-order mode enabled", () => {
+  const restored = normalizeFormState({
+    platform: "coinbase",
+    binanceLive: true,
+    tradeArmed: true,
+  });
+  assert.equal(restored.platform, "coinbase");
+  assert.equal(restored.binanceLive, true);
+  assert.equal(restored.tradeArmed, true);
+});
+
+test("rebalance cost defaults stay aligned with backend defaults", () => {
+  assert.equal(defaultForm.rebalanceCostMult, 0);
+  const optimizerDefaults = buildDefaultOptimizerRunForm("BTCUSDT", "binance");
+  assert.equal(optimizerDefaults.rebalanceCostMultMin, "");
+  assert.equal(optimizerDefaults.rebalanceCostMultMax, "");
+});
+
+test("methodLabel includes kalman_physics_error", () => {
+  assert.equal(methodLabel("kalman_physics_error"), "Kalman physics error");
+});

--- a/haskell/web/test/utils.test.mjs
+++ b/haskell/web/test/utils.test.mjs
@@ -3,15 +3,40 @@ import { test } from "node:test";
 import {
   buildOrphanedPositions,
   buildRequestIssueDetails,
+  downsampleIndices,
   inferFlyApiAppName,
   inferFlyDirectApiBaseFromHostname,
   isLocalHostname,
   methodLabel,
   normalizeApiBaseUrlInput,
   numFromInput,
+  remapIndexToSample,
   summarizeOrderSizing,
 } from "../.tmp/web-tests/utils.js";
 import { defaultForm, normalizeFormState } from "../.tmp/web-tests/formState.js";
+
+function assertStrictlyIncreasing(values, context) {
+  for (let i = 1; i < values.length; i += 1) {
+    assert.ok(
+      values[i - 1] < values[i],
+      `${context}: expected strictly increasing indices, got ${values[i - 1]} then ${values[i]}`,
+    );
+  }
+}
+
+function expectedNearestSampleIndex(indices, idx) {
+  if (indices.length === 0) return 0;
+  let bestIndex = 0;
+  let bestDistance = Math.abs(indices[0] - idx);
+  for (let i = 1; i < indices.length; i += 1) {
+    const distance = Math.abs(indices[i] - idx);
+    if (distance < bestDistance) {
+      bestIndex = i;
+      bestDistance = distance;
+    }
+  }
+  return bestIndex;
+}
 
 test("buildRequestIssueDetails returns empty when clean", () => {
   assert.deepEqual(buildRequestIssueDetails({}), []);
@@ -148,6 +173,81 @@ test("numFromInput parses thousands grouping and decimal comma consistently", ()
   assert.equal(numFromInput("1,234,567", 0), 1234567);
   assert.equal(numFromInput("1,23", 0), 1.23);
   assert.equal(numFromInput("0,123", 0), 0.123);
+});
+
+test("downsampleIndices preserves bounded chart sampling invariants", () => {
+  for (let total = 0; total <= 257; total += 1) {
+    for (let maxPoints = 0; maxPoints <= 65; maxPoints += 1) {
+      const indices = downsampleIndices(total, maxPoints);
+      const budget = Math.max(1, Math.trunc(maxPoints));
+
+      if (total === 0) {
+        assert.deepEqual(indices, []);
+        continue;
+      }
+
+      assert.ok(indices.length >= 1, `expected a visible point for total=${total}, maxPoints=${maxPoints}`);
+      assert.ok(
+        indices.length <= Math.min(total, budget),
+        `expected sample budget for total=${total}, maxPoints=${maxPoints}, got ${indices.length}`,
+      );
+      assert.equal(indices[0], 0, `expected first endpoint for total=${total}, maxPoints=${maxPoints}`);
+      assertStrictlyIncreasing(indices, `total=${total}, maxPoints=${maxPoints}`);
+      for (const idx of indices) {
+        assert.ok(idx >= 0 && idx < total, `expected in-bounds sample ${idx} for total=${total}, maxPoints=${maxPoints}`);
+      }
+      if (indices.length > 1) {
+        assert.equal(
+          indices[indices.length - 1],
+          total - 1,
+          `expected final endpoint for total=${total}, maxPoints=${maxPoints}`,
+        );
+      }
+      if (total <= budget) {
+        assert.deepEqual(indices, Array.from({ length: total }, (_, i) => i));
+      }
+    }
+  }
+});
+
+test("remapIndexToSample preserves exact sampled hits", () => {
+  for (let total = 1; total <= 257; total += 1) {
+    for (let maxPoints = 0; maxPoints <= 65; maxPoints += 1) {
+      const indices = downsampleIndices(total, maxPoints);
+      for (let sampleIdx = 0; sampleIdx < indices.length; sampleIdx += 1) {
+        const rawIdx = indices[sampleIdx];
+        assert.equal(
+          remapIndexToSample(indices, rawIdx),
+          sampleIdx,
+          `expected exact sampled hit for total=${total}, maxPoints=${maxPoints}, rawIdx=${rawIdx}`,
+        );
+      }
+    }
+  }
+});
+
+test("remapIndexToSample chooses nearest visible points with deterministic left-biased ties", () => {
+  assert.equal(remapIndexToSample([], 42), 0);
+  assert.equal(remapIndexToSample([0, 4, 8], 2), 0);
+  assert.equal(remapIndexToSample([0, 4, 8], 6), 1);
+
+  for (let total = 1; total <= 257; total += 1) {
+    for (let maxPoints = 0; maxPoints <= 65; maxPoints += 1) {
+      const indices = downsampleIndices(total, maxPoints);
+      for (let rawIdx = 0; rawIdx < total; rawIdx += 1) {
+        const mapped = remapIndexToSample(indices, rawIdx);
+        assert.ok(
+          mapped >= 0 && mapped < indices.length,
+          `expected mapped index in range for total=${total}, maxPoints=${maxPoints}, rawIdx=${rawIdx}`,
+        );
+        assert.equal(
+          mapped,
+          expectedNearestSampleIndex(indices, rawIdx),
+          `expected nearest visible point for total=${total}, maxPoints=${maxPoints}, rawIdx=${rawIdx}`,
+        );
+      }
+    }
+  }
 });
 
 test("summarizeOrderSizing blocks trade when no effective size is configured", () => {

--- a/haskell/web/test/utils.test.mjs
+++ b/haskell/web/test/utils.test.mjs
@@ -229,6 +229,92 @@ test("normalizeFormState restores default minPositionSize for invalid input", ()
   assert.equal(fromExplicitZero.minPositionSize, 0);
 });
 
+test("normalizeFormState rehydrates manual sizing fields as finite numbers", () => {
+  const restored = normalizeFormState({
+    orderQuote: "125.5",
+    orderQuantity: "0.25",
+    orderQuoteFraction: "0.4",
+    maxOrderQuote: "50",
+  });
+  assert.deepEqual(
+    {
+      orderQuote: restored.orderQuote,
+      orderQuantity: restored.orderQuantity,
+      orderQuoteFraction: restored.orderQuoteFraction,
+      maxOrderQuote: restored.maxOrderQuote,
+    },
+    {
+      orderQuote: 125.5,
+      orderQuantity: 0.25,
+      orderQuoteFraction: 0.4,
+      maxOrderQuote: 50,
+    },
+  );
+  for (const value of [restored.orderQuote, restored.orderQuantity, restored.orderQuoteFraction, restored.maxOrderQuote]) {
+    assert.equal(typeof value, "number");
+    assert.equal(Number.isFinite(value), true);
+  }
+
+  const fallback = normalizeFormState({
+    orderQuote: "Infinity",
+    orderQuantity: Number.NaN,
+    orderQuoteFraction: "not-a-number",
+    maxOrderQuote: "-Infinity",
+  });
+  assert.deepEqual(
+    {
+      orderQuote: fallback.orderQuote,
+      orderQuantity: fallback.orderQuantity,
+      orderQuoteFraction: fallback.orderQuoteFraction,
+      maxOrderQuote: fallback.maxOrderQuote,
+    },
+    {
+      orderQuote: defaultForm.orderQuote,
+      orderQuantity: defaultForm.orderQuantity,
+      orderQuoteFraction: defaultForm.orderQuoteFraction,
+      maxOrderQuote: defaultForm.maxOrderQuote,
+    },
+  );
+});
+
+test("normalizeFormState preserves restored fraction validation and precedence", () => {
+  const invalidFractionOnly = normalizeFormState({
+    orderQuote: 0,
+    orderQuantity: 0,
+    orderQuoteFraction: "1.25",
+    maxOrderQuote: "40",
+  });
+  const invalidFractionState = summarizeOrderSizing({
+    orderQuantity: invalidFractionOnly.orderQuantity,
+    orderQuote: invalidFractionOnly.orderQuote,
+    orderQuoteFraction: invalidFractionOnly.orderQuoteFraction,
+    maxOrderQuote: invalidFractionOnly.maxOrderQuote,
+  });
+  assert.equal(invalidFractionOnly.orderQuoteFraction, 1.25);
+  assert.equal(invalidFractionOnly.maxOrderQuote, 40);
+  assert.equal(invalidFractionState.fractionError, "Order quote fraction must be <= 1 (use 0 to disable).");
+  assert.equal(invalidFractionState.blockingError, "Order quote fraction must be <= 1 (use 0 to disable).");
+  assert.equal(invalidFractionState.blockingTargetId, "orderQuoteFraction");
+
+  const precedenceRestored = normalizeFormState({
+    orderQuantity: "0.25",
+    orderQuote: "100",
+    orderQuoteFraction: "1.25",
+    maxOrderQuote: "40",
+  });
+  const precedenceState = summarizeOrderSizing({
+    orderQuantity: precedenceRestored.orderQuantity,
+    orderQuote: precedenceRestored.orderQuote,
+    orderQuoteFraction: precedenceRestored.orderQuoteFraction,
+    maxOrderQuote: precedenceRestored.maxOrderQuote,
+  });
+  assert.deepEqual(precedenceState.active, ["orderQuantity", "orderQuote"]);
+  assert.equal(precedenceState.effective, "orderQuantity");
+  assert.equal(precedenceState.fractionError, "Order quote fraction must be <= 1 (use 0 to disable).");
+  assert.equal(precedenceState.blockingError, null);
+  assert.equal(precedenceState.tone, "warn");
+});
+
 test("defaultForm uses safe trade defaults", () => {
   assert.equal(defaultForm.binanceLive, false);
   assert.equal(defaultForm.tradeArmed, false);
@@ -249,7 +335,7 @@ test("normalizeFormState normalizes trade toggles and booleans from strings", ()
   assert.equal(out.autoRefresh, false);
 });
 
-test("normalizeFormState forces non-binance platforms into spot + disables binance-only flags", () => {
+test("normalizeFormState forces non-binance platforms into spot and preserves coinbase live mode", () => {
   const out = normalizeFormState({
     platform: "coinbase",
     market: "futures",
@@ -260,7 +346,7 @@ test("normalizeFormState forces non-binance platforms into spot + disables binan
   assert.equal(out.platform, "coinbase");
   assert.equal(out.market, "spot");
   assert.equal(out.binanceTestnet, false);
-  assert.equal(out.binanceLive, false);
+  assert.equal(out.binanceLive, true);
   assert.equal(out.tradeArmed, true);
 });
 

--- a/scripts/codex-logical-correctness-loop.sh
+++ b/scripts/codex-logical-correctness-loop.sh
@@ -1,0 +1,394 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+STATE_DIR="${ROOT_DIR}/.tmp/codex-logical-correctness-loop"
+LOG_DIR="${STATE_DIR}/logs"
+BASELINE_FILE="${STATE_DIR}/baseline-status.txt"
+RUN_LOG="${STATE_DIR}/runner.log"
+mkdir -p "${LOG_DIR}"
+
+CODEX_MODEL="${CODEX_LOOP_MODEL:-gpt-5.4}"
+POLL_SECONDS="${CODEX_LOOP_POLL_SECONDS:-45}"
+CI_TIMEOUT_MINUTES="${CODEX_LOOP_CI_TIMEOUT_MINUTES:-60}"
+SLEEP_BETWEEN_CYCLES="${CODEX_LOOP_CYCLE_SLEEP_SECONDS:-20}"
+ALLOW_DIRTY="${CODEX_LOOP_ALLOW_DIRTY:-0}"
+MAX_CYCLES="${CODEX_LOOP_MAX_CYCLES:-0}"
+
+log() {
+  printf '[%s] %s\n' "$(date '+%Y-%m-%d %H:%M:%S')" "$*" | tee -a "${RUN_LOG}"
+}
+
+require_cmd() {
+  command -v "$1" >/dev/null 2>&1 || {
+    echo "Missing required command: $1" >&2
+    exit 1
+  }
+}
+
+trim_file() {
+  local file="$1"
+  local lines="${2:-400}"
+  if [[ -f "$file" ]]; then
+    tail -n "$lines" "$file"
+  fi
+}
+
+capture_baseline() {
+  git -C "${ROOT_DIR}" status --porcelain=v1 > "${BASELINE_FILE}"
+}
+
+baseline_paths_block() {
+  if [[ ! -s "${BASELINE_FILE}" ]]; then
+    return 0
+  fi
+  awk '{print substr($0,4)}' "${BASELINE_FILE}" | sed '/^$/d' | sed 's/^/- /'
+}
+
+repo_status_block() {
+  git -C "${ROOT_DIR}" status --short
+}
+
+ensure_baseline_policy() {
+  capture_baseline
+  if [[ "${ALLOW_DIRTY}" != "1" ]] && [[ -s "${BASELINE_FILE}" ]]; then
+    echo "Repository is dirty. Re-run with CODEX_LOOP_ALLOW_DIRTY=1 to preserve current changes as protected baseline." >&2
+    echo "Current status:" >&2
+    repo_status_block >&2
+    exit 1
+  fi
+}
+
+has_non_baseline_changes() {
+  local current tmp
+  current="$(mktemp)"
+  tmp="$(mktemp)"
+  git -C "${ROOT_DIR}" status --porcelain=v1 > "$current"
+  if [[ -s "${BASELINE_FILE}" ]]; then
+    grep -Fvx -f "${BASELINE_FILE}" "$current" > "$tmp" || true
+  else
+    cp "$current" "$tmp"
+  fi
+  if [[ -s "$tmp" ]]; then
+    rm -f "$current" "$tmp"
+    return 0
+  fi
+  rm -f "$current" "$tmp"
+  return 1
+}
+
+current_branch() {
+  git -C "${ROOT_DIR}" branch --show-current | tr -d '[:space:]'
+}
+
+codex_prompt() {
+  local name="$1"
+  local prompt_file="$2"
+  local output_file="$3"
+  log "Running Codex step: ${name}"
+  codex exec --full-auto -m "${CODEX_MODEL}" -C "${ROOT_DIR}" --color never -o "${output_file}" - < "${prompt_file}"
+  trim_file "${output_file}" 200 | tee -a "${RUN_LOG}" >/dev/null || true
+}
+
+make_prompt_file() {
+  local file="$1"
+  cat > "$file"
+}
+
+wait_for_ci_runs() {
+  local sha="$1"
+  local deadline=$(( $(date +%s) + CI_TIMEOUT_MINUTES * 60 ))
+  local branch
+  branch="$(current_branch)"
+  while true; do
+    local runs_file
+    runs_file="$(mktemp)"
+    gh run list \
+      --repo "$(gh repo view --json nameWithOwner -q .nameWithOwner)" \
+      --branch "$branch" \
+      --commit "$sha" \
+      --json databaseId,displayTitle,workflowName,status,conclusion,url,headSha \
+      > "$runs_file"
+
+    local total pending failed success
+    total="$(jq 'length' "$runs_file")"
+    pending="$(jq '[.[] | select((.status // "") != "completed")] | length' "$runs_file")"
+    failed="$(jq '[.[] | select((.status // "") == "completed" and ((.conclusion // "") != "success" and (.conclusion // "") != "neutral" and (.conclusion // "") != "skipped"))] | length' "$runs_file")"
+    success="$(jq '[.[] | select((.status // "") == "completed" and (.conclusion // "") == "success")] | length' "$runs_file")"
+
+    if [[ "$failed" -gt 0 ]]; then
+      cat "$runs_file"
+      rm -f "$runs_file"
+      return 10
+    fi
+
+    if [[ "$total" -gt 0 && "$pending" -eq 0 ]]; then
+      log "All detected GitHub Actions are green for ${sha} (${success}/${total} successful)."
+      rm -f "$runs_file"
+      return 0
+    fi
+
+    if [[ $(date +%s) -ge "$deadline" ]]; then
+      cat "$runs_file"
+      rm -f "$runs_file"
+      return 11
+    fi
+
+    log "Waiting for GitHub Actions for ${sha} (total=${total}, pending=${pending}, success=${success})..."
+    rm -f "$runs_file"
+    sleep "$POLL_SECONDS"
+  done
+}
+
+build_detect_prompt() {
+  local prompt_file="$1"
+  make_prompt_file "$prompt_file" <<EOF
+You are Codex working inside this repository:
+${ROOT_DIR}
+
+Task:
+Detect anything that could be made more logical and correct.
+
+Instructions:
+- Audit logic, correctness, edge cases, invariants, broken assumptions, bad state transitions, stale conditionals, wrong defaults, incorrect parsing/typing, and likely CI/runtime correctness issues.
+- Prefer concrete, actionable findings over vague suggestions.
+- Do NOT modify files in this step.
+- Return a prioritized markdown list with file paths and why each issue matters.
+- If you genuinely find nothing worth fixing right now, output exactly: NO_ISSUES
+
+Protected baseline paths from before this loop started (do not stage/commit these unless explicitly required by the new fix):
+$(baseline_paths_block)
+EOF
+}
+
+build_implement_prompt() {
+  local prompt_file="$1"
+  local findings_file="$2"
+  make_prompt_file "$prompt_file" <<EOF
+You are Codex working inside this repository:
+${ROOT_DIR}
+
+Task:
+Implement fixes for all of the logic/correctness issues listed below.
+
+Requirements:
+- Make the smallest robust changes that fix the issues.
+- Run relevant local verification where practical.
+- Update tests/docs/changelog if warranted.
+- Do NOT commit or push in this step.
+- Do NOT modify or stage protected baseline paths unless absolutely necessary for the new fixes.
+- At the end, print exactly one of:
+  IMPLEMENT_RESULT: changed
+  IMPLEMENT_RESULT: no_changes
+  IMPLEMENT_RESULT: blocked
+
+Protected baseline paths from before this loop started:
+$(baseline_paths_block)
+
+Findings to fix:
+---
+$(cat "$findings_file")
+---
+EOF
+}
+
+build_commit_push_prompt() {
+  local prompt_file="$1"
+  make_prompt_file "$prompt_file" <<EOF
+You are Codex working inside this repository:
+${ROOT_DIR}
+
+Task:
+Commit and push the fixes from this iteration.
+
+Requirements:
+- Review the current git diff/status.
+- Commit only files relevant to the current iteration's fixes.
+- Do NOT stage or commit protected baseline paths that predated this loop unless they were intentionally part of the new fixes.
+- Push the current branch to origin.
+- If there is nothing to commit for this iteration, output exactly: COMMIT_PUSH_RESULT: no_changes
+- If you successfully commit and push, end with exactly: COMMIT_PUSH_RESULT: pushed
+- If blocked, end with exactly: COMMIT_PUSH_RESULT: blocked
+
+Protected baseline paths:
+$(baseline_paths_block)
+EOF
+}
+
+build_ci_fix_prompt() {
+  local prompt_file="$1"
+  local sha="$2"
+  local logs_file="$3"
+  make_prompt_file "$prompt_file" <<EOF
+You are Codex working inside this repository:
+${ROOT_DIR}
+
+Task:
+GitHub Actions failed for commit ${sha}. Fix all issues evidenced by these CI logs.
+
+Requirements:
+- Focus only on issues supported by the logs.
+- Make the smallest robust fixes.
+- Run relevant local verification where practical.
+- Do NOT commit or push in this step.
+- Do NOT modify or stage protected baseline paths unless absolutely necessary for the CI fix.
+- End with exactly one of:
+  CI_FIX_RESULT: changed
+  CI_FIX_RESULT: no_changes
+  CI_FIX_RESULT: blocked
+
+Protected baseline paths:
+$(baseline_paths_block)
+
+CI logs:
+---
+$(cat "$logs_file")
+---
+EOF
+}
+
+collect_failed_logs() {
+  local runs_json_file="$1"
+  local logs_file="$2"
+  : > "$logs_file"
+  jq -r '.[] | select((.status // "") == "completed" and ((.conclusion // "") != "success" and (.conclusion // "") != "neutral" and (.conclusion // "") != "skipped")) | [.databaseId, (.workflowName // .displayTitle // "unknown"), (.url // "")] | @tsv' "$runs_json_file" |
+  while IFS=$'\t' read -r run_id run_name run_url; do
+    {
+      echo "===== FAILED RUN: ${run_name} (${run_id}) ====="
+      echo "URL: ${run_url}"
+      gh run view "$run_id" --log-failed 2>/dev/null || gh run view "$run_id" --log || true
+      echo
+    } >> "$logs_file"
+  done
+}
+
+main() {
+  require_cmd codex
+  require_cmd gh
+  require_cmd jq
+  require_cmd git
+
+  ensure_baseline_policy
+
+  local cycle=1
+  while [[ "$MAX_CYCLES" == "0" || "$cycle" -le "$MAX_CYCLES" ]]; do
+    log "=== Cycle ${cycle} starting in ${ROOT_DIR} ==="
+
+    local detect_prompt detect_output
+    detect_prompt="$(mktemp)"
+    detect_output="${LOG_DIR}/cycle-${cycle}-detect.md"
+    build_detect_prompt "$detect_prompt"
+    codex_prompt "detect" "$detect_prompt" "$detect_output"
+    rm -f "$detect_prompt"
+
+    if grep -Fxq 'NO_ISSUES' "$detect_output"; then
+      log "Codex reported no logic/correctness issues. Sleeping ${SLEEP_BETWEEN_CYCLES}s."
+      sleep "$SLEEP_BETWEEN_CYCLES"
+      cycle=$((cycle + 1))
+      continue
+    fi
+
+    local implement_prompt implement_output
+    implement_prompt="$(mktemp)"
+    implement_output="${LOG_DIR}/cycle-${cycle}-implement.md"
+    build_implement_prompt "$implement_prompt" "$detect_output"
+    codex_prompt "implement" "$implement_prompt" "$implement_output"
+    rm -f "$implement_prompt"
+
+    if grep -Fxq 'IMPLEMENT_RESULT: blocked' "$implement_output"; then
+      log "Codex reported blocked during implementation. Stopping loop."
+      exit 1
+    fi
+
+    if ! has_non_baseline_changes; then
+      log "No non-baseline changes detected after implementation. Sleeping ${SLEEP_BETWEEN_CYCLES}s."
+      sleep "$SLEEP_BETWEEN_CYCLES"
+      cycle=$((cycle + 1))
+      continue
+    fi
+
+    local commit_prompt commit_output
+    commit_prompt="$(mktemp)"
+    commit_output="${LOG_DIR}/cycle-${cycle}-commit-push.md"
+    build_commit_push_prompt "$commit_prompt"
+    codex_prompt "commit-push" "$commit_prompt" "$commit_output"
+    rm -f "$commit_prompt"
+
+    if grep -Fxq 'COMMIT_PUSH_RESULT: blocked' "$commit_output"; then
+      log "Codex reported blocked during commit/push. Stopping loop."
+      exit 1
+    fi
+    if grep -Fxq 'COMMIT_PUSH_RESULT: no_changes' "$commit_output"; then
+      log "Codex reported no changes to commit. Sleeping ${SLEEP_BETWEEN_CYCLES}s."
+      sleep "$SLEEP_BETWEEN_CYCLES"
+      cycle=$((cycle + 1))
+      continue
+    fi
+
+    local sha
+    sha="$(git -C "${ROOT_DIR}" rev-parse HEAD)"
+    log "Pushed commit ${sha}. Polling GitHub Actions."
+
+    while true; do
+      local runs_json
+      runs_json="${LOG_DIR}/cycle-${cycle}-runs.json"
+      if wait_for_ci_runs "$sha" > "$runs_json"; then
+        break
+      fi
+      local rc=$?
+      if [[ "$rc" -eq 11 ]]; then
+        log "Timed out waiting for CI for ${sha}. Stopping loop."
+        exit 1
+      fi
+      if [[ "$rc" -ne 10 ]]; then
+        log "Unexpected CI polling result (${rc}) for ${sha}. Stopping loop."
+        exit 1
+      fi
+
+      local ci_logs_file
+      ci_logs_file="${LOG_DIR}/cycle-${cycle}-ci-failures.log"
+      collect_failed_logs "$runs_json" "$ci_logs_file"
+
+      local ci_fix_prompt ci_fix_output
+      ci_fix_prompt="$(mktemp)"
+      ci_fix_output="${LOG_DIR}/cycle-${cycle}-ci-fix.md"
+      build_ci_fix_prompt "$ci_fix_prompt" "$sha" "$ci_logs_file"
+      codex_prompt "ci-fix" "$ci_fix_prompt" "$ci_fix_output"
+      rm -f "$ci_fix_prompt"
+
+      if grep -Fxq 'CI_FIX_RESULT: blocked' "$ci_fix_output"; then
+        log "Codex reported blocked during CI fix. Stopping loop."
+        exit 1
+      fi
+
+      if ! has_non_baseline_changes; then
+        log "Codex did not create non-baseline changes after CI failure. Stopping loop."
+        exit 1
+      fi
+
+      commit_prompt="$(mktemp)"
+      commit_output="${LOG_DIR}/cycle-${cycle}-commit-push-ci.md"
+      build_commit_push_prompt "$commit_prompt"
+      codex_prompt "commit-push-after-ci-fix" "$commit_prompt" "$commit_output"
+      rm -f "$commit_prompt"
+
+      if grep -Fxq 'COMMIT_PUSH_RESULT: blocked' "$commit_output"; then
+        log "Codex blocked during commit/push after CI fix. Stopping loop."
+        exit 1
+      fi
+      if grep -Fxq 'COMMIT_PUSH_RESULT: no_changes' "$commit_output"; then
+        log "No changes to commit after CI fix attempt. Stopping loop."
+        exit 1
+      fi
+
+      sha="$(git -C "${ROOT_DIR}" rev-parse HEAD)"
+      log "Pushed follow-up commit ${sha}. Re-polling GitHub Actions."
+    done
+
+    log "Cycle ${cycle} finished green. Sleeping ${SLEEP_BETWEEN_CYCLES}s before next cycle."
+    sleep "$SLEEP_BETWEEN_CYCLES"
+    cycle=$((cycle + 1))
+  done
+}
+
+main "$@"


### PR DESCRIPTION
Autonomous improvement loop.

Summary: Chosen change: add bounded property-style coverage for `downsampleIndices` and `remapIndexToSample` in `haskell/web/test/utils.test.mjs`. UI review: inspected `haskell/web/src/components/BacktestChart.tsx` hover, tooltip, and trade-marker alignment assumptions and kept runtime code unchanged because the existing helper contract remains UX-safe. Correctness review: the new tests lock strict monotonicity, max-point budget, conditional endpoint retention, exact sampled-hit remapping, and deterministic left-biased nearest-visible-point ties.

Branch: `autoloop/main`
Base: `main`