### PR TITLE
Trading: add technical analysis strategy batch

### DIFF
--- a/haskell/app/Trader/TechnicalAnalysis/Indicators.hs
+++ b/haskell/app/Trader/TechnicalAnalysis/Indicators.hs
@@ -1,0 +1,566 @@
+module Trader.TechnicalAnalysis.Indicators (
+    AdxPoint (..),
+    AroonPoint (..),
+    Band (..),
+    DonchianChannel (..),
+    MacdPoint (..),
+    accumulationDistributionSeries,
+    adxSeries,
+    aroonSeries,
+    atrSeries,
+    bollingerBandsSeries,
+    cmfSeries,
+    donchianChannelsSeries,
+    emaSeries,
+    keltnerChannelsSeries,
+    latestJust,
+    macdSeries,
+    mfiSeries,
+    obvSeries,
+    rocSeries,
+    rsiSeries,
+    smaSeries,
+    stochasticKSeries,
+    vptSeries,
+) where
+
+import Data.List (foldl')
+import Data.Maybe (catMaybes)
+import qualified Data.Vector as V
+
+-- | Generic band container used for Bollinger/Keltner channels.
+data Band = Band
+    { bandLower :: !Double
+    , bandMiddle :: !Double
+    , bandUpper :: !Double
+    }
+    deriving (Eq, Show)
+
+-- | Latest MACD values for a bar.
+data MacdPoint = MacdPoint
+    { macdValue :: !Double
+    , macdSignal :: !Double
+    , macdHistogram :: !Double
+    }
+    deriving (Eq, Show)
+
+-- | ADX plus directional movement components.
+data AdxPoint = AdxPoint
+    { adxValue :: !Double
+    , adxPlusDi :: !Double
+    , adxMinusDi :: !Double
+    }
+    deriving (Eq, Show)
+
+-- | Aroon up/down scores over a lookback window.
+data AroonPoint = AroonPoint
+    { aroonUp :: !Double
+    , aroonDown :: !Double
+    }
+    deriving (Eq, Show)
+
+-- | Donchian upper/lower bands.
+data DonchianChannel = DonchianChannel
+    { donchianLower :: !Double
+    , donchianUpper :: !Double
+    }
+    deriving (Eq, Show)
+
+latestJust :: V.Vector (Maybe a) -> Maybe a
+latestJust values =
+    go (V.length values - 1)
+  where
+    go idx
+        | idx < 0 = Nothing
+        | otherwise =
+            case values V.! idx of
+                Just value -> Just value
+                Nothing -> go (idx - 1)
+
+smaSeries :: Int -> V.Vector Double -> V.Vector (Maybe Double)
+smaSeries period values
+    | period <= 0 = V.replicate (V.length values) Nothing
+    | otherwise =
+        V.generate n step
+  where
+    n = V.length values
+    step idx
+        | idx + 1 < period = Nothing
+        | otherwise =
+            let start = idx + 1 - period
+                window = V.slice start period values
+             in Just (V.sum window / fromIntegral period)
+
+emaSeries :: Int -> V.Vector Double -> V.Vector (Maybe Double)
+emaSeries period values
+    | period <= 0 = V.replicate (V.length values) Nothing
+    | V.length values < period = V.replicate (V.length values) Nothing
+    | otherwise =
+        let seedWindow = V.slice 0 period values
+            seed = V.sum seedWindow / fromIntegral period
+            multiplier = 2 / (fromIntegral period + 1)
+            prefix = replicate (period - 1) Nothing ++ [Just seed]
+            tailValues = V.toList (V.slice period (V.length values - period) values)
+            (_, rest) =
+                foldl'
+                    ( \(prevEma, acc) price ->
+                        let nextEma = ((price - prevEma) * multiplier) + prevEma
+                         in (nextEma, acc ++ [Just nextEma])
+                    )
+                    (seed, prefix)
+                    tailValues
+         in V.fromList rest
+
+rocSeries :: Int -> V.Vector Double -> V.Vector (Maybe Double)
+rocSeries period values
+    | period <= 0 = V.replicate (V.length values) Nothing
+    | otherwise =
+        V.generate (V.length values) step
+  where
+    step idx
+        | idx < period = Nothing
+        | otherwise =
+            let prev = values V.! (idx - period)
+                cur = values V.! idx
+             in if prev == 0 then Nothing else Just (((cur - prev) / prev) * 100)
+
+rsiSeries :: Int -> V.Vector Double -> V.Vector (Maybe Double)
+rsiSeries period values
+    | period <= 0 = V.replicate n Nothing
+    | n <= period = V.replicate n Nothing
+    | otherwise =
+        let deltas = [values V.! i - values V.! (i - 1) | i <- [1 .. n - 1]]
+            gains = map (max 0) deltas
+            losses = map (max 0 . negate) deltas
+            avgGain0 = sum (take period gains) / fromIntegral period
+            avgLoss0 = sum (take period losses) / fromIntegral period
+            firstRsi = rsiFromAverages avgGain0 avgLoss0
+            prefix = replicate period Nothing ++ [Just firstRsi]
+            tailPairs = drop period (zip gains losses)
+            (_, _, out) =
+                foldl'
+                    ( \(avgGain, avgLoss, acc) (gainValue, lossValue) ->
+                        let nextGain = ((avgGain * fromIntegral (period - 1)) + gainValue) / fromIntegral period
+                            nextLoss = ((avgLoss * fromIntegral (period - 1)) + lossValue) / fromIntegral period
+                         in (nextGain, nextLoss, acc ++ [Just (rsiFromAverages nextGain nextLoss)])
+                    )
+                    (avgGain0, avgLoss0, prefix)
+                    tailPairs
+         in V.fromList out
+  where
+    n = V.length values
+
+stochasticKSeries :: Int -> V.Vector Double -> V.Vector Double -> V.Vector Double -> V.Vector (Maybe Double)
+stochasticKSeries period highs lows closes
+    | period <= 0 = V.replicate n Nothing
+    | not (sameLength [highs, lows, closes]) = V.replicate n Nothing
+    | otherwise =
+        V.generate n step
+  where
+    n = V.length closes
+    step idx
+        | idx + 1 < period = Nothing
+        | otherwise =
+            let start = idx + 1 - period
+                highWindow = V.slice start period highs
+                lowWindow = V.slice start period lows
+                highestHigh = V.maximum highWindow
+                lowestLow = V.minimum lowWindow
+                rangeValue = highestHigh - lowestLow
+                closeValue = closes V.! idx
+             in if rangeValue == 0 then Nothing else Just (((closeValue - lowestLow) / rangeValue) * 100)
+
+macdSeries :: Int -> Int -> Int -> V.Vector Double -> V.Vector (Maybe MacdPoint)
+macdSeries fastPeriod slowPeriod signalPeriod closes
+    | fastPeriod <= 0 || slowPeriod <= 0 || signalPeriod <= 0 = V.replicate n Nothing
+    | fastPeriod >= slowPeriod = V.replicate n Nothing
+    | otherwise =
+        let fastEma = emaSeries fastPeriod closes
+            slowEma = emaSeries slowPeriod closes
+            macdLine = V.zipWith combine fastEma slowEma
+            signalLine = emaSeriesFromMaybe signalPeriod macdLine
+         in V.generate n (step macdLine signalLine)
+  where
+    n = V.length closes
+    combine (Just fastValue) (Just slowValue) = Just (fastValue - slowValue)
+    combine _ _ = Nothing
+    step macdLine signalLine idx =
+        case (macdLine V.! idx, signalLine V.! idx) of
+            (Just macdValueNow, Just signalValueNow) ->
+                Just
+                    MacdPoint
+                        { macdValue = macdValueNow
+                        , macdSignal = signalValueNow
+                        , macdHistogram = macdValueNow - signalValueNow
+                        }
+            _ -> Nothing
+
+atrSeries :: Int -> V.Vector Double -> V.Vector Double -> V.Vector Double -> V.Vector (Maybe Double)
+atrSeries period highs lows closes
+    | period <= 0 = V.replicate n Nothing
+    | not (sameLength [highs, lows, closes]) = V.replicate n Nothing
+    | n == 0 = V.empty
+    | n <= period = V.replicate n Nothing
+    | otherwise =
+        let trueRanges = V.generate n trAt
+            seed = V.sum (V.slice 1 period trueRanges) / fromIntegral period
+            prefix = replicate period Nothing ++ [Just seed]
+            tailValues = V.toList (V.slice (period + 1) (n - period - 1) trueRanges)
+            (_, out) =
+                foldl'
+                    ( \(prevAtr, acc) trValue ->
+                        let nextAtr = ((prevAtr * fromIntegral (period - 1)) + trValue) / fromIntegral period
+                         in (nextAtr, acc ++ [Just nextAtr])
+                    )
+                    (seed, prefix)
+                    tailValues
+         in V.fromList out
+  where
+    n = V.length closes
+    trAt 0 = highs V.! 0 - lows V.! 0
+    trAt idx =
+        let highValue = highs V.! idx
+            lowValue = lows V.! idx
+            prevClose = closes V.! (idx - 1)
+         in maximum
+                [ highValue - lowValue
+                , abs (highValue - prevClose)
+                , abs (lowValue - prevClose)
+                ]
+
+adxSeries :: Int -> V.Vector Double -> V.Vector Double -> V.Vector Double -> V.Vector (Maybe AdxPoint)
+adxSeries period highs lows closes
+    | period <= 0 = V.replicate n Nothing
+    | not (sameLength [highs, lows, closes]) = V.replicate n Nothing
+    | n <= (period * 2) = V.replicate n Nothing
+    | otherwise =
+        let plusDm = V.generate n plusDmAt
+            minusDm = V.generate n minusDmAt
+            atrVals = atrSeries period highs lows closes
+            smoothPlusDm = smoothedSeries period plusDm
+            smoothMinusDm = smoothedSeries period minusDm
+            dxSeriesValues =
+                V.generate n (dxAt atrVals smoothPlusDm smoothMinusDm)
+            seedDx = averageMaybes (V.slice period period dxSeriesValues)
+            prefix = replicate (period * 2 - 1) Nothing ++ [seedDx]
+            restDx = V.toList (V.slice (period * 2) (n - (period * 2)) dxSeriesValues)
+            (_, out) =
+                case seedDx of
+                    Nothing -> (0, replicate n Nothing)
+                    Just seedValue ->
+                        foldl'
+                            ( \(prevAdx, acc) nextDx ->
+                                case nextDx of
+                                    Nothing -> (prevAdx, acc ++ [Nothing])
+                                    Just dxValue ->
+                                        let nextAdx = ((prevAdx * fromIntegral (period - 1)) + dxValue) / fromIntegral period
+                                         in (nextAdx, acc ++ [Just nextAdx])
+                            )
+                            (seedValue, prefix)
+                            restDx
+         in V.generate n (assemble atrVals smoothPlusDm smoothMinusDm (V.fromList out))
+  where
+    n = V.length closes
+    plusDmAt 0 = 0
+    plusDmAt idx =
+        let upMove = highs V.! idx - highs V.! (idx - 1)
+            downMove = lows V.! (idx - 1) - lows V.! idx
+         in if upMove > downMove && upMove > 0 then upMove else 0
+    minusDmAt 0 = 0
+    minusDmAt idx =
+        let upMove = highs V.! idx - highs V.! (idx - 1)
+            downMove = lows V.! (idx - 1) - lows V.! idx
+         in if downMove > upMove && downMove > 0 then downMove else 0
+    dxAt atrVals plusVals minusVals idx =
+        case (atrVals V.! idx, plusVals V.! idx, minusVals V.! idx) of
+            (Just atrValue, Just plusValue, Just minusValue)
+                | atrValue > 0 ->
+                    let plusDiValue = (plusValue / atrValue) * 100
+                        minusDiValue = (minusValue / atrValue) * 100
+                        denom = plusDiValue + minusDiValue
+                     in if denom == 0 then Nothing else Just ((abs (plusDiValue - minusDiValue) / denom) * 100)
+            _ -> Nothing
+    assemble atrVals plusVals minusVals adxVals idx =
+        case (atrVals V.! idx, plusVals V.! idx, minusVals V.! idx, adxVals V.! idx) of
+            (Just atrValue, Just plusValue, Just minusValue, Just adxValueNow)
+                | atrValue > 0 ->
+                    let plusDiValue = (plusValue / atrValue) * 100
+                        minusDiValue = (minusValue / atrValue) * 100
+                     in Just
+                            AdxPoint
+                                { adxValue = adxValueNow
+                                , adxPlusDi = plusDiValue
+                                , adxMinusDi = minusDiValue
+                                }
+            _ -> Nothing
+
+aroonSeries :: Int -> V.Vector Double -> V.Vector Double -> V.Vector (Maybe AroonPoint)
+aroonSeries period highs lows
+    | period <= 1 = V.replicate n Nothing
+    | V.length highs /= V.length lows = V.replicate n Nothing
+    | otherwise =
+        V.generate n step
+  where
+    n = V.length highs
+    step idx
+        | idx + 1 < period = Nothing
+        | otherwise =
+            let start = idx + 1 - period
+                highWindow = V.slice start period highs
+                lowWindow = V.slice start period lows
+                highestIdx = V.maxIndex highWindow
+                lowestIdx = V.minIndex lowWindow
+                barsSinceHigh = period - 1 - highestIdx
+                barsSinceLow = period - 1 - lowestIdx
+                scale = 100 / fromIntegral (period - 1)
+             in Just
+                    AroonPoint
+                        { aroonUp = 100 - fromIntegral barsSinceHigh * scale
+                        , aroonDown = 100 - fromIntegral barsSinceLow * scale
+                        }
+
+bollingerBandsSeries :: Int -> Double -> V.Vector Double -> V.Vector (Maybe Band)
+bollingerBandsSeries period stdevMult closes
+    | period <= 1 = V.replicate n Nothing
+    | otherwise =
+        V.generate n step
+  where
+    n = V.length closes
+    step idx
+        | idx + 1 < period = Nothing
+        | otherwise =
+            let start = idx + 1 - period
+                window = V.slice start period closes
+                meanValue = V.sum window / fromIntegral period
+                variance = V.sum (V.map (\x -> let d = x - meanValue in d * d) window) / fromIntegral period
+                sigma = sqrt variance
+             in Just
+                    Band
+                        { bandLower = meanValue - (stdevMult * sigma)
+                        , bandMiddle = meanValue
+                        , bandUpper = meanValue + (stdevMult * sigma)
+                        }
+
+keltnerChannelsSeries :: Int -> Double -> V.Vector Double -> V.Vector Double -> V.Vector Double -> V.Vector (Maybe Band)
+keltnerChannelsSeries period atrMult highs lows closes =
+    let middle = emaSeries period closes
+        atrVals = atrSeries period highs lows closes
+     in V.generate n (step middle atrVals)
+  where
+    n = V.length closes
+    step middle atrVals idx =
+        case (middle V.! idx, atrVals V.! idx) of
+            (Just middleValue, Just atrValue) ->
+                Just
+                    Band
+                        { bandLower = middleValue - (atrMult * atrValue)
+                        , bandMiddle = middleValue
+                        , bandUpper = middleValue + (atrMult * atrValue)
+                        }
+            _ -> Nothing
+
+donchianChannelsSeries :: Int -> V.Vector Double -> V.Vector Double -> V.Vector (Maybe DonchianChannel)
+donchianChannelsSeries period highs lows
+    | period <= 0 = V.replicate n Nothing
+    | V.length highs /= V.length lows = V.replicate n Nothing
+    | otherwise =
+        V.generate n step
+  where
+    n = V.length highs
+    step idx
+        | idx + 1 < period = Nothing
+        | otherwise =
+            let start = idx + 1 - period
+                highWindow = V.slice start period highs
+                lowWindow = V.slice start period lows
+             in Just
+                    DonchianChannel
+                        { donchianLower = V.minimum lowWindow
+                        , donchianUpper = V.maximum highWindow
+                        }
+
+obvSeries :: V.Vector Double -> V.Vector Double -> V.Vector (Maybe Double)
+obvSeries closes volumes
+    | V.length closes /= V.length volumes = V.replicate (max (V.length closes) (V.length volumes)) Nothing
+    | V.null closes = V.empty
+    | otherwise = V.fromList (go 1 0 [Just 0])
+  where
+    n = V.length closes
+    go idx prevObv acc
+        | idx >= n = reverse acc
+        | otherwise =
+            let closeNow = closes V.! idx
+                closePrev = closes V.! (idx - 1)
+                volumeNow = volumes V.! idx
+                nextObv
+                    | closeNow > closePrev = prevObv + volumeNow
+                    | closeNow < closePrev = prevObv - volumeNow
+                    | otherwise = prevObv
+             in go (idx + 1) nextObv (Just nextObv : acc)
+
+accumulationDistributionSeries :: V.Vector Double -> V.Vector Double -> V.Vector Double -> V.Vector Double -> V.Vector (Maybe Double)
+accumulationDistributionSeries highs lows closes volumes
+    | not (sameLength [highs, lows, closes, volumes]) = V.replicate n Nothing
+    | n == 0 = V.empty
+    | otherwise = V.fromList (reverse (snd (foldl' step (0, []) [0 .. n - 1])))
+  where
+    n = V.length closes
+    step (prevValue, acc) idx =
+        let highValue = highs V.! idx
+            lowValue = lows V.! idx
+            closeValue = closes V.! idx
+            volumeValue = volumes V.! idx
+            rangeValue = highValue - lowValue
+            moneyFlowMultiplier =
+                if rangeValue == 0
+                    then 0
+                    else ((closeValue - lowValue) - (highValue - closeValue)) / rangeValue
+            nextValue = prevValue + (moneyFlowMultiplier * volumeValue)
+         in (nextValue, Just nextValue : acc)
+
+cmfSeries :: Int -> V.Vector Double -> V.Vector Double -> V.Vector Double -> V.Vector Double -> V.Vector (Maybe Double)
+cmfSeries period highs lows closes volumes
+    | period <= 0 = V.replicate n Nothing
+    | otherwise =
+        V.generate n step
+  where
+    n = V.length closes
+    step idx
+        | idx + 1 < period = Nothing
+        | otherwise =
+            let start = idx + 1 - period
+                moneyFlowVolumes =
+                    V.generate
+                        period
+                        ( \offset ->
+                            let i = start + offset
+                                highValue = highs V.! i
+                                lowValue = lows V.! i
+                                closeValue = closes V.! i
+                                volumeValue = volumes V.! i
+                                rangeValue = highValue - lowValue
+                                multiplier =
+                                    if rangeValue == 0
+                                        then 0
+                                        else ((closeValue - lowValue) - (highValue - closeValue)) / rangeValue
+                             in multiplier * volumeValue
+                        )
+                volumeWindow = V.slice start period volumes
+                denom = V.sum volumeWindow
+             in if denom == 0 then Nothing else Just (V.sum moneyFlowVolumes / denom)
+
+mfiSeries :: Int -> V.Vector Double -> V.Vector Double -> V.Vector Double -> V.Vector Double -> V.Vector (Maybe Double)
+mfiSeries period highs lows closes volumes
+    | period <= 0 = V.replicate n Nothing
+    | not (sameLength [highs, lows, closes, volumes]) = V.replicate n Nothing
+    | n <= period = V.replicate n Nothing
+    | otherwise =
+        V.generate n step
+  where
+    n = V.length closes
+    typicalPrice idx = ((highs V.! idx) + (lows V.! idx) + (closes V.! idx)) / 3
+    rawMoneyFlow idx = typicalPrice idx * (volumes V.! idx)
+    step idx
+        | idx < period = Nothing
+        | otherwise =
+            let indices = [idx - period + 1 .. idx]
+                (positiveFlow, negativeFlow) =
+                    foldl'
+                        ( \(posAcc, negAcc) i ->
+                            if i == 0
+                                then (posAcc, negAcc)
+                                else
+                                    let prevTypical = typicalPrice (i - 1)
+                                        curTypical = typicalPrice i
+                                        flowValue = rawMoneyFlow i
+                                     in if curTypical > prevTypical
+                                            then (posAcc + flowValue, negAcc)
+                                            else
+                                                if curTypical < prevTypical
+                                                    then (posAcc, negAcc + flowValue)
+                                                    else (posAcc, negAcc)
+                        )
+                        (0, 0)
+                        indices
+             in if negativeFlow == 0
+                    then Just 100
+                    else
+                        let moneyRatio = positiveFlow / negativeFlow
+                         in Just (100 - (100 / (1 + moneyRatio)))
+
+vptSeries :: V.Vector Double -> V.Vector Double -> V.Vector (Maybe Double)
+vptSeries closes volumes
+    | V.length closes /= V.length volumes = V.replicate (max (V.length closes) (V.length volumes)) Nothing
+    | V.null closes = V.empty
+    | otherwise = V.fromList (go 1 0 [Just 0])
+  where
+    n = V.length closes
+    go idx prevVpt acc
+        | idx >= n = reverse acc
+        | otherwise =
+            let closeNow = closes V.! idx
+                closePrev = closes V.! (idx - 1)
+                volumeNow = volumes V.! idx
+                delta = if closePrev == 0 then 0 else ((closeNow - closePrev) / closePrev) * volumeNow
+                nextVpt = prevVpt + delta
+             in go (idx + 1) nextVpt (Just nextVpt : acc)
+
+sameLength :: [V.Vector a] -> Bool
+sameLength [] = True
+sameLength (x : xs) = all ((== V.length x) . V.length) xs
+
+rsiFromAverages :: Double -> Double -> Double
+rsiFromAverages avgGain avgLoss
+    | avgLoss == 0 = 100
+    | otherwise =
+        let rs = avgGain / avgLoss
+         in 100 - (100 / (1 + rs))
+
+averageMaybes :: V.Vector (Maybe Double) -> Maybe Double
+averageMaybes values =
+    let present = catMaybes (V.toList values)
+     in if null present then Nothing else Just (sum present / fromIntegral (length present))
+
+emaSeriesFromMaybe :: Int -> V.Vector (Maybe Double) -> V.Vector (Maybe Double)
+emaSeriesFromMaybe period values
+    | period <= 0 = V.replicate (V.length values) Nothing
+    | otherwise =
+        let indexed = [(idx, value) | (idx, Just value) <- zip [0 ..] (V.toList values)]
+         in if length indexed < period
+                then V.replicate (V.length values) Nothing
+                else
+                    let seedEntries = take period indexed
+                        seed = sum (map snd seedEntries) / fromIntegral period
+                        seedIndex = fst (last seedEntries)
+                        multiplier = 2 / (fromIntegral period + 1)
+                        initial = replicate seedIndex Nothing ++ [Just seed]
+                        (_, out) =
+                            foldl'
+                                ( \(prevEma, acc) (_, value) ->
+                                    let nextEma = ((value - prevEma) * multiplier) + prevEma
+                                     in (nextEma, acc ++ [Just nextEma])
+                                )
+                                (seed, initial)
+                                (drop period indexed)
+                        padded = out ++ replicate (V.length values - length out) Nothing
+                     in V.fromList padded
+
+smoothedSeries :: Int -> V.Vector Double -> V.Vector (Maybe Double)
+smoothedSeries period values
+    | period <= 0 = V.replicate n Nothing
+    | n <= period = V.replicate n Nothing
+    | otherwise =
+        let seed = V.sum (V.slice 1 period values)
+            prefix = replicate period Nothing ++ [Just seed]
+            tailValues = V.toList (V.slice (period + 1) (n - period - 1) values)
+            (_, out) =
+                foldl'
+                    ( \(prevSmooth, acc) nextValue ->
+                        let nextSmooth = prevSmooth - (prevSmooth / fromIntegral period) + nextValue
+                         in (nextSmooth, acc ++ [Just nextSmooth])
+                    )
+                    (seed, prefix)
+                    tailValues
+         in V.fromList out
+  where
+    n = V.length values

--- a/haskell/app/Trader/TechnicalAnalysis/Strategies.hs
+++ b/haskell/app/Trader/TechnicalAnalysis/Strategies.hs
@@ -1,0 +1,270 @@
+module Trader.TechnicalAnalysis.Strategies (
+    OhlcvSeries (..),
+    Regime (..),
+    StrategyCandidate (..),
+    TradeBias (..),
+    momentumReversionCandidate,
+    regimeSelector,
+    strategyCandidates,
+    trendFollowingCandidate,
+    volumeConfirmedBreakoutCandidate,
+) where
+
+import qualified Data.Vector as V
+import Trader.TechnicalAnalysis.Indicators
+
+data OhlcvSeries = OhlcvSeries
+    { ohlcvOpen :: !(V.Vector Double)
+    , ohlcvHigh :: !(V.Vector Double)
+    , ohlcvLow :: !(V.Vector Double)
+    , ohlcvClose :: !(V.Vector Double)
+    , ohlcvVolume :: !(V.Vector Double)
+    }
+    deriving (Eq, Show)
+
+data Regime = RegimeTrend | RegimeRange | RegimeNeutral
+    deriving (Eq, Show)
+
+data TradeBias = BiasLong | BiasShort | BiasFlat
+    deriving (Eq, Show)
+
+data StrategyCandidate = StrategyCandidate
+    { scFamily :: !String
+    , scName :: !String
+    , scBias :: !TradeBias
+    , scConfidence :: !Double
+    , scEntryPrice :: !(Maybe Double)
+    , scStopPrice :: !(Maybe Double)
+    , scTakeProfitPrice :: !(Maybe Double)
+    , scReason :: !String
+    }
+    deriving (Eq, Show)
+
+strategyCandidates :: OhlcvSeries -> [StrategyCandidate]
+strategyCandidates series =
+    catMaybes
+        [ trendFollowingCandidate series
+        , momentumReversionCandidate series
+        , volumeConfirmedBreakoutCandidate series
+        ]
+
+regimeSelector :: OhlcvSeries -> Maybe Regime
+regimeSelector series = do
+    validateSeries series
+    closeNow <- lastValue (ohlcvClose series)
+    adxNow <- latestJust (adxSeries 14 (ohlcvHigh series) (ohlcvLow series) (ohlcvClose series))
+    aroonNow <- latestJust (aroonSeries 25 (ohlcvHigh series) (ohlcvLow series))
+    fastNow <- latestJust (emaSeries 20 (ohlcvClose series))
+    fastPrev <- laggedJust 5 (emaSeries 20 (ohlcvClose series))
+    bbNow <- latestJust (bollingerBandsSeries 20 2 (ohlcvClose series))
+    let slope = safeDivide (fastNow - fastPrev) closeNow
+        width = safeDivide (bandUpper bbNow - bandLower bbNow) closeNow
+        aroonGap = abs (aroonUp aroonNow - aroonDown aroonNow)
+    if adxValue adxNow >= 25 && aroonGap >= 40 && abs slope >= 0.01
+        then Just RegimeTrend
+        else
+            if adxValue adxNow < 20 && width <= 0.08
+                then Just RegimeRange
+                else Just RegimeNeutral
+
+trendFollowingCandidate :: OhlcvSeries -> Maybe StrategyCandidate
+trendFollowingCandidate series = do
+    validateSeries series
+    closeNow <- lastValue (ohlcvClose series)
+    fastNow <- latestJust (emaSeries 20 (ohlcvClose series))
+    slowNow <- latestJust (emaSeries 50 (ohlcvClose series))
+    adxNow <- latestJust (adxSeries 14 (ohlcvHigh series) (ohlcvLow series) (ohlcvClose series))
+    aroonNow <- latestJust (aroonSeries 25 (ohlcvHigh series) (ohlcvLow series))
+    atrNow <- latestJust (atrSeries 14 (ohlcvHigh series) (ohlcvLow series) (ohlcvClose series))
+    regimeNow <- regimeSelector series
+    let longTrend =
+            regimeNow == RegimeTrend
+                && fastNow > slowNow
+                && adxValue adxNow >= 20
+                && aroonUp aroonNow > aroonDown aroonNow
+        shortTrend =
+            regimeNow == RegimeTrend
+                && fastNow < slowNow
+                && adxValue adxNow >= 20
+                && aroonDown aroonNow > aroonUp aroonNow
+        maSpread = abs (safeDivide (fastNow - slowNow) closeNow)
+        baseConfidence = clamp01 (((adxValue adxNow - 20) / 25) + (maSpread * 8) + (abs (aroonUp aroonNow - aroonDown aroonNow) / 100)) / 3
+     in if longTrend
+            then
+                Just
+                    StrategyCandidate
+                        { scFamily = "trend-following"
+                        , scName = "ema-crossover-adx-aroon-atr"
+                        , scBias = BiasLong
+                        , scConfidence = baseConfidence
+                        , scEntryPrice = Just closeNow
+                        , scStopPrice = Just (closeNow - (2 * atrNow))
+                        , scTakeProfitPrice = Just (closeNow + (3 * atrNow))
+                        , scReason = "Fast EMA is above slow EMA with ADX/Aroon trend confirmation and ATR-based risk framing."
+                        }
+            else
+                if shortTrend
+                    then
+                        Just
+                            StrategyCandidate
+                                { scFamily = "trend-following"
+                                , scName = "ema-crossover-adx-aroon-atr"
+                                , scBias = BiasShort
+                                , scConfidence = baseConfidence
+                                , scEntryPrice = Just closeNow
+                                , scStopPrice = Just (closeNow + (2 * atrNow))
+                                , scTakeProfitPrice = Just (closeNow - (3 * atrNow))
+                                , scReason = "Fast EMA is below slow EMA with ADX/Aroon trend confirmation and ATR-based risk framing."
+                                }
+                    else Nothing
+
+momentumReversionCandidate :: OhlcvSeries -> Maybe StrategyCandidate
+momentumReversionCandidate series = do
+    validateSeries series
+    regimeNow <- regimeSelector series
+    closeNow <- lastValue (ohlcvClose series)
+    rsiNow <- latestJust (rsiSeries 14 (ohlcvClose series))
+    stochasticNow <- latestJust (stochasticKSeries 14 (ohlcvHigh series) (ohlcvLow series) (ohlcvClose series))
+    rocNow <- latestJust (rocSeries 10 (ohlcvClose series))
+    macdNow <- latestJust (macdSeries 12 26 9 (ohlcvClose series))
+    bollingerNow <- latestJust (bollingerBandsSeries 20 2 (ohlcvClose series))
+    keltnerNow <- latestJust (keltnerChannelsSeries 20 1.5 (ohlcvHigh series) (ohlcvLow series) (ohlcvClose series))
+    atrNow <- latestJust (atrSeries 14 (ohlcvHigh series) (ohlcvLow series) (ohlcvClose series))
+    let nearLowerEnvelope = closeNow <= max (bandLower bollingerNow) (bandLower keltnerNow) * 1.02
+        nearUpperEnvelope = closeNow >= min (bandUpper bollingerNow) (bandUpper keltnerNow) * 0.98
+        longSetup =
+            regimeNow /= RegimeTrend
+                && rsiNow <= 35
+                && stochasticNow <= 20
+                && rocNow < 0
+                && macdValue macdNow >= macdSignal macdNow
+                && nearLowerEnvelope
+        shortSetup =
+            regimeNow /= RegimeTrend
+                && rsiNow >= 65
+                && stochasticNow >= 80
+                && rocNow > 0
+                && macdValue macdNow <= macdSignal macdNow
+                && nearUpperEnvelope
+        baseConfidence = clamp01 ((abs (50 - rsiNow) / 50) + (abs (50 - stochasticNow) / 50) + min 1 (abs rocNow / 5)) / 3
+     in if longSetup
+            then
+                Just
+                    StrategyCandidate
+                        { scFamily = "momentum-reversion"
+                        , scName = "rsi-stochastic-roc-macd-envelope"
+                        , scBias = BiasLong
+                        , scConfidence = baseConfidence
+                        , scEntryPrice = Just closeNow
+                        , scStopPrice = Just (closeNow - (1.5 * atrNow))
+                        , scTakeProfitPrice = Just (bandMiddle bollingerNow)
+                        , scReason = "Range-style long setup: RSI/Stochastic oversold, negative ROC, MACD confirmation, lower envelope context."
+                        }
+            else
+                if shortSetup
+                    then
+                        Just
+                            StrategyCandidate
+                                { scFamily = "momentum-reversion"
+                                , scName = "rsi-stochastic-roc-macd-envelope"
+                                , scBias = BiasShort
+                                , scConfidence = baseConfidence
+                                , scEntryPrice = Just closeNow
+                                , scStopPrice = Just (closeNow + (1.5 * atrNow))
+                                , scTakeProfitPrice = Just (bandMiddle bollingerNow)
+                                , scReason = "Range-style short setup: RSI/Stochastic overbought, positive ROC, MACD confirmation, upper envelope context."
+                                }
+                    else Nothing
+
+volumeConfirmedBreakoutCandidate :: OhlcvSeries -> Maybe StrategyCandidate
+volumeConfirmedBreakoutCandidate series = do
+    validateSeries series
+    closeNow <- lastValue (ohlcvClose series)
+    let donchianSeries = donchianChannelsSeries 20 (ohlcvHigh series) (ohlcvLow series)
+    donchianNow <- laggedJust 1 donchianSeries
+    atrNow <- latestJust (atrSeries 14 (ohlcvHigh series) (ohlcvLow series) (ohlcvClose series))
+    obvNow <- latestJust (obvSeries (ohlcvClose series) (ohlcvVolume series))
+    obvPrev <- laggedJust 5 (obvSeries (ohlcvClose series) (ohlcvVolume series))
+    adNow <- latestJust (accumulationDistributionSeries (ohlcvHigh series) (ohlcvLow series) (ohlcvClose series) (ohlcvVolume series))
+    adPrev <- laggedJust 5 (accumulationDistributionSeries (ohlcvHigh series) (ohlcvLow series) (ohlcvClose series) (ohlcvVolume series))
+    cmfNow <- latestJust (cmfSeries 20 (ohlcvHigh series) (ohlcvLow series) (ohlcvClose series) (ohlcvVolume series))
+    mfiNow <- latestJust (mfiSeries 14 (ohlcvHigh series) (ohlcvLow series) (ohlcvClose series) (ohlcvVolume series))
+    vptNow <- latestJust (vptSeries (ohlcvClose series) (ohlcvVolume series))
+    vptPrev <- laggedJust 5 (vptSeries (ohlcvClose series) (ohlcvVolume series))
+    let obvUp = obvNow > obvPrev
+        adUp = adNow > adPrev
+        vptUp = vptNow > vptPrev
+        longBreakout = closeNow > donchianUpper donchianNow && obvUp && adUp && vptUp && cmfNow > 0 && mfiNow >= 50
+        shortBreakout = closeNow < donchianLower donchianNow && not obvUp && not adUp && not vptUp && cmfNow < 0 && mfiNow <= 50
+        breakoutDistance = max 0 (safeDivide (abs (closeNow - midChannel donchianNow)) closeNow)
+        baseConfidence = clamp01 ((if obvUp == adUp then 1 else 0.5) + min 1 (abs cmfNow) + min 1 breakoutDistance * 10) / 3
+     in if longBreakout
+            then
+                Just
+                    StrategyCandidate
+                        { scFamily = "volume-confirmed-breakout"
+                        , scName = "donchian-obv-ad-cmf-mfi-vpt"
+                        , scBias = BiasLong
+                        , scConfidence = baseConfidence
+                        , scEntryPrice = Just closeNow
+                        , scStopPrice = Just (closeNow - (2 * atrNow))
+                        , scTakeProfitPrice = Just (closeNow + (4 * atrNow))
+                        , scReason = "Upper-channel breakout confirmed by OBV/A-D/VPT slope plus CMF/MFI support."
+                        }
+            else
+                if shortBreakout
+                    then
+                        Just
+                            StrategyCandidate
+                                { scFamily = "volume-confirmed-breakout"
+                                , scName = "donchian-obv-ad-cmf-mfi-vpt"
+                                , scBias = BiasShort
+                                , scConfidence = baseConfidence
+                                , scEntryPrice = Just closeNow
+                                , scStopPrice = Just (closeNow + (2 * atrNow))
+                                , scTakeProfitPrice = Just (closeNow - (4 * atrNow))
+                                , scReason = "Lower-channel breakout confirmed by OBV/A-D/VPT weakness plus CMF/MFI support."
+                                }
+                    else Nothing
+
+validateSeries :: OhlcvSeries -> Maybe ()
+validateSeries series
+    | not (sameLength [ohlcvOpen series, ohlcvHigh series, ohlcvLow series, ohlcvClose series, ohlcvVolume series]) = Nothing
+    | V.length (ohlcvClose series) < 60 = Nothing
+    | otherwise = Just ()
+
+sameLength :: [V.Vector a] -> Bool
+sameLength [] = True
+sameLength (x : xs) = all ((== V.length x) . V.length) xs
+
+lastValue :: V.Vector a -> Maybe a
+lastValue values
+    | V.null values = Nothing
+    | otherwise = Just (V.last values)
+
+laggedJust :: Int -> V.Vector (Maybe a) -> Maybe a
+laggedJust offset values =
+    go (V.length values - 1 - offset)
+  where
+    go idx
+        | idx < 0 = Nothing
+        | otherwise =
+            case values V.! idx of
+                Just value -> Just value
+                Nothing -> go (idx - 1)
+
+safeDivide :: Double -> Double -> Double
+safeDivide _ 0 = 0
+safeDivide numerator denominator = numerator / denominator
+
+clamp01 :: Double -> Double
+clamp01 = max 0 . min 1
+
+midChannel :: DonchianChannel -> Double
+midChannel channel = (donchianUpper channel + donchianLower channel) / 2
+
+catMaybes :: [Maybe a] -> [a]
+catMaybes = foldr step []
+  where
+    step (Just value) acc = value : acc
+    step Nothing acc = acc

--- a/haskell/test/TestMain.hs
+++ b/haskell/test/TestMain.hs
@@ -38,6 +38,7 @@ import Trader.SignalGates (
     signalRegimeEdgeOk,
     signalRunPostDirectionGates,
  )
+import Trader.Test.TechnicalAnalysis (runTechnicalAnalysisTests)
 import Trader.Trading (
     BacktestCostAttribution (..),
     BacktestResult (..),
@@ -101,6 +102,7 @@ main = do
     testOptimizerQualityBudgetRegression
     testOptimizerKellyLiteExposureContractRegression
     testMetricsConsumesTradingPublicResults
+    runTechnicalAnalysisTests
 
 assert :: String -> Bool -> IO ()
 assert message condition =

--- a/haskell/test/Trader/Test/TechnicalAnalysis.hs
+++ b/haskell/test/Trader/Test/TechnicalAnalysis.hs
@@ -1,0 +1,88 @@
+module Trader.Test.TechnicalAnalysis (runTechnicalAnalysisTests) where
+
+import Control.Monad (unless)
+import Data.Maybe (catMaybes, isNothing)
+import qualified Data.Vector as V
+import Trader.TechnicalAnalysis.Indicators
+import Trader.TechnicalAnalysis.Strategies
+
+runTechnicalAnalysisTests :: IO ()
+runTechnicalAnalysisTests = do
+    testEmaPrefixInvariance
+    testRsiBounds
+    testAtrNonNegative
+    testAroonPeriodOneFailsClosed
+    testRegimeSelectorFindsTrend
+    testTrendCandidateFailsClosedOnShortSeries
+    testBreakoutCandidateCanTriggerLong
+
+assert :: String -> Bool -> IO ()
+assert message condition =
+    unless condition (ioError (userError ("Assertion failed: " ++ message)))
+
+testEmaPrefixInvariance :: IO ()
+testEmaPrefixInvariance = do
+    let closes = V.fromList [100 + fromIntegral i | i <- [0 .. 79]]
+        prefix = V.take 40 closes
+        fullEma = emaSeries 10 closes
+        prefixEma = emaSeries 10 prefix
+    assert "emaSeries is prefix-invariant at the same bar" (prefixEma V.! 39 == fullEma V.! 39)
+
+testRsiBounds :: IO ()
+testRsiBounds = do
+    let closes = V.fromList [100, 101, 102, 101, 103, 104, 102, 105, 104, 106, 107, 105, 108, 110, 109, 111, 112, 110, 113, 114, 116]
+        rsis = rsiSeries 14 closes
+        present = catMaybes (V.toList rsis)
+    assert "rsiSeries emits bounded RSI values" (all (\value -> value >= 0 && value <= 100) present)
+
+testAtrNonNegative :: IO ()
+testAtrNonNegative = do
+    let closes = V.fromList [100 + fromIntegral i * 0.5 | i <- [0 .. 79]]
+        highs = V.map (+ 1.2) closes
+        lows = V.map (subtract 1.1) closes
+        atrs = atrSeries 14 highs lows closes
+        present = catMaybes (V.toList atrs)
+    assert "atrSeries is non-negative" (all (>= 0) present)
+
+testAroonPeriodOneFailsClosed :: IO ()
+testAroonPeriodOneFailsClosed = do
+    let highs = V.fromList [101, 102, 103]
+        lows = V.fromList [99, 98, 97]
+    assert "aroonSeries period 1 fails closed" (V.all (== Nothing) (aroonSeries 1 highs lows))
+
+testRegimeSelectorFindsTrend :: IO ()
+testRegimeSelectorFindsTrend = do
+    let closes = V.fromList [100 + fromIntegral i * 1.5 | i <- [0 .. 119]]
+        highs = V.map (+ 1.0) closes
+        lows = V.map (subtract 1.0) closes
+        opens = V.map (subtract 0.4) closes
+        volumes = V.fromList [1000 + fromIntegral (i * 10) | i <- [0 .. 119]]
+        series = OhlcvSeries opens highs lows closes volumes
+    assert "regimeSelector identifies a clean synthetic trend" (regimeSelector series == Just RegimeTrend)
+
+testTrendCandidateFailsClosedOnShortSeries :: IO ()
+testTrendCandidateFailsClosedOnShortSeries = do
+    let closes = V.fromList [100 + fromIntegral i | i <- [0 .. 39]]
+        highs = V.map (+ 1) closes
+        lows = V.map (subtract 1) closes
+        opens = V.map (subtract 0.5) closes
+        volumes = V.replicate 40 1000
+        series = OhlcvSeries opens highs lows closes volumes
+    assert "trendFollowingCandidate fails closed on short history" (isNothing (trendFollowingCandidate series))
+
+testBreakoutCandidateCanTriggerLong :: IO ()
+testBreakoutCandidateCanTriggerLong = do
+    let base = [100 + fromIntegral i * 0.2 | i <- [0 .. 58]]
+        closes = V.fromList (base ++ [120, 123, 126, 130, 135, 140])
+        highs = V.map (+ 0.5) closes
+        lows = V.map (subtract 1.5) closes
+        opens = V.map (subtract 0.3) closes
+        volumes = V.fromList ([1000 + fromIntegral i * 5 | i <- [0 .. 58]] ++ [2000, 2200, 2400, 2600, 2800, 3000])
+        series = OhlcvSeries opens highs lows closes volumes
+        candidate = volumeConfirmedBreakoutCandidate series
+    assert
+        "volumeConfirmedBreakoutCandidate can produce a long breakout candidate on synthetic breakout data"
+        ( case candidate of
+            Just signal -> scBias signal == BiasLong
+            Nothing -> False
+        )

--- a/haskell/trader.cabal
+++ b/haskell/trader.cabal
@@ -64,6 +64,8 @@ executable trader-hs
                      , Trader.Symbol
                      , Trader.TopCombosStore
                      , Trader.S3
+                     , Trader.TechnicalAnalysis.Indicators
+                     , Trader.TechnicalAnalysis.Strategies
                      , Trader.Text
                      , Trader.Trading
                      , Trader.VolConfGate
@@ -257,6 +259,9 @@ test-suite trader-tests
                      , Trader.Test.Cors
                      , Trader.TopCombosStore
                      , Trader.Test.ApiRoutes
+                     , Trader.TechnicalAnalysis.Indicators
+                     , Trader.TechnicalAnalysis.Strategies
+                     , Trader.Test.TechnicalAnalysis
                      , Trader.Text
                      , Trader.Trading
                      , Trader.VolConfGate


### PR DESCRIPTION
## Summary
- Add reusable Haskell technical-analysis indicators covering trend, momentum, volatility/channel, and volume families.
- Add first-pass strategy candidates for EMA/ADX/Aroon trend following, RSI/Stochastic/ROC/MACD envelope reversion, and Donchian breakout with OBV/A-D/CMF/MFI/VPT confirmation.
- Add regression coverage for indicator bounds, no-lookahead EMA prefix behavior, fail-closed short history, Aroon period 1, and a synthetic breakout candidate.

## Validation
- `bash scripts/verify.sh haskell` passed after restoring Cabal's previous local index-state with `cabal v2-update hackage.haskell.org,2026-01-31T23:35:39Z` because today's index selected uncached packages and Cabal download failed with `repoContextWithSecureRepo: unknown repo`.

## Tracking
- Closes #106
- Closes #107
- Closes #108

## Notes
- This PR introduces strategy candidate modules and tests only; it does not wire these candidates into live execution defaults.

## Post-merge follow-up
- Follow-up commit `f227bbea` landed on `main` via merge commit `b001a951` after this PR merged.
- That follow-up adds gated TA candidate admission, fixes confidence averaging before clamping, pins `haskell/cabal.project` to `2026-01-31T23:35:39Z`, and extends Haskell regression coverage.