### PR TITLE
[codex] ops: repair live schema migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## Unreleased
+- Ops/API: add an idempotent migration for existing PostgreSQL ops tables so `/api/ops` and `/api/ops/performance` can recover columns added after the original migration version was recorded instead of returning 500s on live dashboards.
 - Trading/Optimizer: distinguish omitted versus explicit threshold max caps in `optimize-equity --quality`, so default caps still widen for quality sweeps while explicit `2e-2` CLI or top-combo wrapper env overrides remain tight; wrapper run-start logs now show requested and effective threshold ranges.
 - Trading: fail closed on malformed fresh-entry position-size bounds by requiring max/min sizing caps to be finite and non-negative before a new backtest entry can open; valid zero caps/floors and valid minimum-size equality remain supported, and tighter valid caps cannot increase realized entry exposure.
 - Bot/Live Trading: reconcile Coinbase live market orders with parsed order status, filled base size, executed quote value, and a bounded order-id lookup before updating bot position state, so successful Coinbase fills no longer look like unknown unfilled live orders.

--- a/haskell/app/Trader/Ops/Migrations.hs
+++ b/haskell/app/Trader/Ops/Migrations.hs
@@ -236,6 +236,31 @@ migrations =
             , "CREATE INDEX IF NOT EXISTS combos_source_idx ON combos(source)"
             ]
         }
+    , Migration
+        { migVersion = 3
+        , migDescription = "ops_live_schema_columns"
+        , migStatements =
+            [ "ALTER TABLE ops ADD COLUMN IF NOT EXISTS tenant_key TEXT"
+            , "ALTER TABLE ops ADD COLUMN IF NOT EXISTS platform_id INTEGER REFERENCES platforms(id)"
+            , "ALTER TABLE ops ADD COLUMN IF NOT EXISTS symbol_id BIGINT REFERENCES platform_symbols(id)"
+            , "ALTER TABLE ops ADD COLUMN IF NOT EXISTS args_json JSONB"
+            , "ALTER TABLE ops ADD COLUMN IF NOT EXISTS result_json JSONB"
+            , "ALTER TABLE ops ADD COLUMN IF NOT EXISTS equity DOUBLE PRECISION"
+            , "ALTER TABLE ops ADD COLUMN IF NOT EXISTS git_commit_id BIGINT REFERENCES git_commits(id)"
+            , "ALTER TABLE git_commits ADD COLUMN IF NOT EXISTS committed_at_ms BIGINT"
+            , "CREATE INDEX IF NOT EXISTS ops_kind_idx ON ops(kind)"
+            , "CREATE INDEX IF NOT EXISTS ops_combo_uuid_idx ON ops(combo_uuid)"
+            , "CREATE INDEX IF NOT EXISTS ops_symbol_idx ON ops(symbol)"
+            , "CREATE INDEX IF NOT EXISTS ops_platform_idx ON ops(platform_id)"
+            , "CREATE INDEX IF NOT EXISTS ops_tenant_key_idx ON ops(tenant_key)"
+            , "CREATE INDEX IF NOT EXISTS ops_symbol_id_idx ON ops(symbol_id)"
+            , "CREATE INDEX IF NOT EXISTS ops_git_commit_id_idx ON ops(git_commit_id)"
+            , "CREATE INDEX IF NOT EXISTS git_commits_committed_at_ms_idx ON git_commits(committed_at_ms)"
+            , "CREATE INDEX IF NOT EXISTS ops_order_id_idx ON ops(order_id)"
+            , "CREATE INDEX IF NOT EXISTS ops_at_ms_idx ON ops(at_ms)"
+            , "CREATE INDEX IF NOT EXISTS ops_symbol_at_ms_idx ON ops(symbol, at_ms)"
+            ]
+        }
     ]
 
 ensureOpsDbSchema :: Connection -> IO ()


### PR DESCRIPTION
## Summary
- Add an idempotent migration version that backfills the live `ops` table columns and indexes expected by current `/api/ops` queries.
- Document the live dashboard 500 recovery in the changelog.

## Root Cause
The production database can have migration version 1 recorded from an older schema. Later `ops` columns such as `args_json`, `result_json`, `equity`, `platform_id`, `symbol_id`, and `git_commit_id` were added inside the already-applied version 1 migration, so existing databases never reran those statements. Current code selects those columns and returns 500 when they are missing.

## Validation
- `bash scripts/verify.sh haskell`
- `git diff --check`

## Deployment
This branch is intentionally limited to the ops migration hotfix so it can be deployed without the in-progress autoloop worktree changes.