### PR TITLE
Switch continuous-improvement autoloop to Claude (Anthropic)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -179,9 +179,17 @@ TRADER_WEBHOOK_EVENTS=bot.started,bot.start_failed,bot.stop,bot.order,bot.halt,t
 TRADER_LSTM_WEIGHTS_DIR=.tmp/lstm
 
 # AI automation (optional; local loops and autoloop helpers)
+# The autoloop prefers Claude (Anthropic) when ANTHROPIC_API_KEY is set, then
+# falls back to OpenAI (OPENAI_API_KEY), then the local Codex CLI.
+ANTHROPIC_API_KEY=
 OPENAI_API_KEY=
 AUTOLOOP_BACKEND=auto
-AUTOLOOP_MODEL=gpt-5.4
+# AUTOLOOP_MODEL overrides the model for whichever backend is active. Leave it
+# empty to use each backend's default (claude-opus-4-8 for Anthropic, gpt-5.4
+# for OpenAI/Codex). Set ANTHROPIC_MODEL/OPENAI_MODEL to change a single backend.
+AUTOLOOP_MODEL=
+ANTHROPIC_MODEL=claude-opus-4-8
+OPENAI_MODEL=gpt-5.4
 AUTOLOOP_MAX_ITERATIONS=2
 AUTOLOOP_FOREVER_INTERVAL_SECONDS=300
 AUTOLOOP_CODEX_REASONING_EFFORT=

--- a/.github/workflows/autoloop.yml
+++ b/.github/workflows/autoloop.yml
@@ -96,13 +96,14 @@ jobs:
       - name: Run autoloop
         env:
           GITHUB_TOKEN: ${{ secrets.AUTOLOOP_PUSH_TOKEN }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           AUTOLOOP_BASE_BRANCH: ${{ github.event.repository.default_branch }}
           AUTOLOOP_MODEL: ${{ github.event.inputs.model || vars.AUTOLOOP_MODEL }}
           AUTOLOOP_MAX_ITERATIONS: ${{ github.event.inputs.max_iterations || vars.AUTOLOOP_MAX_ITERATIONS || '2' }}
         run: |
-          if [[ -z "${OPENAI_API_KEY:-}" ]]; then
-            echo "::warning::OPENAI_API_KEY is not set; skipping autoloop."
+          if [[ -z "${ANTHROPIC_API_KEY:-}" && -z "${OPENAI_API_KEY:-}" ]]; then
+            echo "::warning::Neither ANTHROPIC_API_KEY nor OPENAI_API_KEY is set; skipping autoloop."
             exit 0
           fi
           if [[ "${{ github.event.inputs.dry_run || 'false' }}" == "true" ]]; then

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,7 +81,7 @@ Avoid mixing formatters (e.g., do not run `stylish-haskell` alongside `ormolu/fo
 ## Gotchas & tips
 - Most low-level Haskell commands still run from the `haskell/` directory, but prefer the repo-root verification wrappers when they exist.
 - Binance credentials must be set via `BINANCE_API_KEY` / `BINANCE_API_SECRET` and should never be logged.
-- GitHub-hosted autoloop additionally requires `OPENAI_API_KEY` and `AUTOLOOP_PUSH_TOKEN` secrets.
+- GitHub-hosted autoloop additionally requires `ANTHROPIC_API_KEY` (preferred) or `OPENAI_API_KEY`, plus `AUTOLOOP_PUSH_TOKEN` secrets.
 
 ## Templates (examples)
 - Verify Haskell: `bash scripts/verify.sh haskell`

--- a/docs/ai-workflow.md
+++ b/docs/ai-workflow.md
@@ -47,11 +47,20 @@ CI also uses `fourmolu 0.15.0.0` and `hlint 3.8`.
 
 ## Local AI automation environment
 
+The autoloop selects its LLM backend from `AUTOLOOP_BACKEND` (default `auto`).
+In `auto` mode it prefers Claude (Anthropic) when `ANTHROPIC_API_KEY` is set,
+then falls back to OpenAI when `OPENAI_API_KEY` is set, then to the local Codex
+CLI. Set `AUTOLOOP_BACKEND` to `anthropic`/`claude`, `openai`, or `codex` to pin
+one explicitly.
+
 Optional local `.env` settings:
 
+- `ANTHROPIC_API_KEY`
 - `OPENAI_API_KEY`
 - `AUTOLOOP_BACKEND`
-- `AUTOLOOP_MODEL`
+- `AUTOLOOP_MODEL` (overrides the active backend's model; defaults to
+  `claude-opus-4-8` for Anthropic, `gpt-5.4` for OpenAI/Codex)
+- `ANTHROPIC_MODEL`
 - `AUTOLOOP_MAX_ITERATIONS`
 - `AUTOLOOP_FOREVER_INTERVAL_SECONDS`
 - `CODEX_LOOP_MODEL`
@@ -61,7 +70,7 @@ These are documented in `.env.example`.
 
 GitHub-hosted autoloop still requires repository secrets:
 
-- `OPENAI_API_KEY`
+- `ANTHROPIC_API_KEY` (or `OPENAI_API_KEY`)
 - `AUTOLOOP_PUSH_TOKEN`
 
 `AUTOLOOP_PUSH_TOKEN` is intentionally a GitHub Actions secret, not a checked-in local default.

--- a/scripts/autoloop-forever.mjs
+++ b/scripts/autoloop-forever.mjs
@@ -255,21 +255,24 @@ async function logRunner(message) {
 
 async function detectPreflightBlock() {
   const requestedBackend = String(process.env.AUTOLOOP_BACKEND || "auto").trim().toLowerCase();
+  const hasAnthropicKey = Boolean(process.env.ANTHROPIC_API_KEY);
   const hasOpenAiKey = Boolean(process.env.OPENAI_API_KEY);
   const hasCodex = commandExists("codex");
   const backendAvailable =
-    requestedBackend === "openai" || requestedBackend === "responses"
-      ? hasOpenAiKey
-      : requestedBackend === "codex"
-        ? hasCodex
-        : hasOpenAiKey || hasCodex;
+    requestedBackend === "anthropic" || requestedBackend === "claude"
+      ? hasAnthropicKey
+      : requestedBackend === "openai" || requestedBackend === "responses"
+        ? hasOpenAiKey
+        : requestedBackend === "codex"
+          ? hasCodex
+          : hasAnthropicKey || hasOpenAiKey || hasCodex;
 
   if (!backendAvailable) {
     return {
       reason:
         requestedBackend && requestedBackend !== "auto"
           ? `requested autoloop backend \"${requestedBackend}\" is unavailable; waiting before the next bounded cycle`
-          : "neither OPENAI_API_KEY nor Codex CLI is available; waiting before the next bounded cycle",
+          : "none of ANTHROPIC_API_KEY, OPENAI_API_KEY, or Codex CLI is available; waiting before the next bounded cycle",
       details: [],
     };
   }

--- a/scripts/autoloop-lib.mjs
+++ b/scripts/autoloop-lib.mjs
@@ -20,6 +20,15 @@ export function extractResponseText(response) {
   return parts.join("\n").trim();
 }
 
+export function extractAnthropicResponseText(response) {
+  const content = Array.isArray(response?.content) ? response.content : [];
+  const parts = [];
+  for (const part of content) {
+    if (part?.type === "text" && typeof part.text === "string") parts.push(part.text);
+  }
+  return parts.join("\n").trim();
+}
+
 export function parseJsonResponse(raw) {
   const text = stripMarkdownFences(raw);
   if (!text) throw new Error("Model returned empty text.");
@@ -436,12 +445,16 @@ export function prepareShellCommand(command) {
   return `source "$HOME/.ghcup/env" 2>/dev/null || true; ${normalized}`;
 }
 
-export function resolveAutoloopBackend(rawBackend, { hasOpenAiKey, hasCodex }) {
+export function resolveAutoloopBackend(rawBackend, { hasAnthropicKey, hasOpenAiKey, hasCodex }) {
   const requested = String(rawBackend ?? "").trim().toLowerCase();
   if (!requested || requested === "auto") {
+    if (hasAnthropicKey) return "anthropic";
     if (hasOpenAiKey) return "openai";
     if (hasCodex) return "codex";
     return "";
+  }
+  if (requested === "anthropic" || requested === "claude") {
+    return hasAnthropicKey ? "anthropic" : "";
   }
   if (requested === "openai" || requested === "responses") {
     return hasOpenAiKey ? "openai" : "";
@@ -513,6 +526,25 @@ export function buildOpenAiApiError(status, payload) {
     code === "insufficient_quota" ||
     type === "insufficient_quota" ||
     authOrPermissionDenied;
+  return err;
+}
+
+export function buildAnthropicApiError(status, payload) {
+  const errorObj = payload?.error && typeof payload.error === "object" ? payload.error : {};
+  const type = typeof errorObj.type === "string" ? errorObj.type : "";
+  const message = typeof errorObj.message === "string" ? errorObj.message : "";
+  const err = new Error(`Anthropic API request failed (${status}): ${JSON.stringify(payload)}`);
+  err.anthropicStatus = Number(status) || 0;
+  err.anthropicType = type;
+  err.anthropicMessage = message;
+  const authOrPermissionDenied =
+    err.anthropicStatus === 401 ||
+    err.anthropicStatus === 403 ||
+    type === "authentication_error" ||
+    type === "permission_error";
+  const billingExhausted =
+    err.anthropicStatus === 402 || /credit balance|billing|quota|insufficient/i.test(message);
+  err.skipAutoloop = authOrPermissionDenied || billingExhausted;
   return err;
 }
 

--- a/scripts/autoloop.mjs
+++ b/scripts/autoloop.mjs
@@ -8,8 +8,10 @@ import { execFileSync } from "node:child_process";
 import {
   buildActionsRunsApiPath,
   buildRemoteTrackingRefspec,
+  buildAnthropicApiError,
   buildOpenAiApiError,
   clampText,
+  extractAnthropicResponseText,
   extractCodexExecLastMessage,
   extractResponseText,
   normalizeIdeaSelection,
@@ -26,6 +28,9 @@ import {
 const ROOT = process.cwd();
 const OPENAI_BASE_URL = (process.env.OPENAI_BASE_URL || "https://api.openai.com/v1").replace(/\/$/, "");
 const OPENAI_MODEL = process.env.AUTOLOOP_MODEL || process.env.OPENAI_MODEL || "gpt-5.4";
+const ANTHROPIC_BASE_URL = (process.env.ANTHROPIC_BASE_URL || "https://api.anthropic.com").replace(/\/$/, "");
+const ANTHROPIC_MODEL = process.env.AUTOLOOP_MODEL || process.env.ANTHROPIC_MODEL || "claude-opus-4-8";
+const ANTHROPIC_VERSION = process.env.ANTHROPIC_VERSION || "2023-06-01";
 const BASE_BRANCH =
   process.env.AUTOLOOP_BASE_BRANCH || process.env.GITHUB_BASE_REF || process.env.GITHUB_REF_NAME || "main";
 const LOOP_BRANCH = BASE_BRANCH;
@@ -64,6 +69,7 @@ const AI_REVIEW_MAX_THREADS = clampInt(process.env.AUTOLOOP_AI_REVIEW_MAX_THREAD
 const AI_REVIEW_THREAD_MAX_CHARS = clampInt(process.env.AUTOLOOP_AI_REVIEW_THREAD_MAX_CHARS, 6000, 1000, 20000);
 const HAS_CODEX = commandExists("codex");
 const PLANNER_BACKEND = resolveAutoloopBackend(REQUESTED_BACKEND, {
+  hasAnthropicKey: Boolean(process.env.ANTHROPIC_API_KEY),
   hasOpenAiKey: Boolean(process.env.OPENAI_API_KEY),
   hasCodex: HAS_CODEX,
 });
@@ -161,7 +167,7 @@ async function main() {
     const message =
       REQUESTED_BACKEND && REQUESTED_BACKEND !== "auto"
         ? `Autoloop backend \"${REQUESTED_BACKEND}\" is unavailable in this workspace; autoloop is skipping.`
-        : "Neither OPENAI_API_KEY nor Codex CLI is available; autoloop is skipping.";
+        : "None of ANTHROPIC_API_KEY, OPENAI_API_KEY, or Codex CLI is available; autoloop is skipping.";
     await updateStatus({ phase: "skipped", outcome: "skipped_missing_backend", message });
     if (DRY_RUN) throw new Error(message);
     console.log(message);
@@ -1231,6 +1237,9 @@ async function callModelJson({ prompt, maxOutputTokens = 4000, timeoutMs = CODEX
   if (PLANNER_BACKEND === "codex") {
     return callModelJsonViaCodex({ prompt, maxOutputTokens, timeoutMs });
   }
+  if (PLANNER_BACKEND === "anthropic") {
+    return callModelJsonViaAnthropic({ prompt, maxOutputTokens });
+  }
 
   const response = await fetch(`${OPENAI_BASE_URL}/responses`, {
     method: "POST",
@@ -1255,6 +1264,36 @@ async function callModelJson({ prompt, maxOutputTokens = 4000, timeoutMs = CODEX
     throw buildOpenAiApiError(response.status, json);
   }
   return parseJsonResponse(extractResponseText(json));
+}
+
+async function callModelJsonViaAnthropic({ prompt, maxOutputTokens }) {
+  const response = await fetch(`${ANTHROPIC_BASE_URL}/v1/messages`, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      "x-api-key": process.env.ANTHROPIC_API_KEY,
+      "anthropic-version": ANTHROPIC_VERSION,
+    },
+    body: JSON.stringify({
+      model: ANTHROPIC_MODEL,
+      max_tokens: maxOutputTokens,
+      temperature: 0.2,
+      system:
+        "Return JSON only. The final output must be a single valid JSON object with no markdown fences and no surrounding prose.",
+      messages: [
+        { role: "user", content: prompt },
+        // Prefill the assistant turn with an opening brace so the model is forced to emit a JSON object.
+        { role: "assistant", content: "{" },
+      ],
+    }),
+  });
+
+  const json = await response.json();
+  if (!response.ok) {
+    throw buildAnthropicApiError(response.status, json);
+  }
+  // The prefilled "{" is not echoed back in the response, so restore it before parsing.
+  return parseJsonResponse(`{${extractAnthropicResponseText(json)}`);
 }
 
 async function callModelJsonViaCodex({ prompt, maxOutputTokens, timeoutMs }) {

--- a/test/autoloop.test.mjs
+++ b/test/autoloop.test.mjs
@@ -16,8 +16,10 @@ import {
   buildActionsRunsApiPath,
   buildForceWithLeaseFlag,
   buildRemoteTrackingRefspec,
+  buildAnthropicApiError,
   buildOpenAiApiError,
   clampText,
+  extractAnthropicResponseText,
   extractCodexExecLastMessage,
   extractResponseText,
   isAutoloopRecoveryBranch,
@@ -610,13 +612,23 @@ test("buildOpenAiApiError marks quota and auth failures as skippable", () => {
   assert.equal(serverErr.skipAutoloop, false);
 });
 
-test("resolveAutoloopBackend prefers OpenAI then Codex in auto mode", () => {
+test("resolveAutoloopBackend prefers Anthropic, then OpenAI, then Codex in auto mode", () => {
+  assert.equal(
+    resolveAutoloopBackend("auto", { hasAnthropicKey: true, hasOpenAiKey: true, hasCodex: true }),
+    "anthropic",
+  );
   assert.equal(resolveAutoloopBackend("auto", { hasOpenAiKey: true, hasCodex: true }), "openai");
   assert.equal(resolveAutoloopBackend("", { hasOpenAiKey: false, hasCodex: true }), "codex");
   assert.equal(resolveAutoloopBackend("", { hasOpenAiKey: false, hasCodex: false }), "");
 });
 
 test("resolveAutoloopBackend respects explicit backend requests", () => {
+  assert.equal(
+    resolveAutoloopBackend("anthropic", { hasAnthropicKey: true, hasOpenAiKey: true, hasCodex: true }),
+    "anthropic",
+  );
+  assert.equal(resolveAutoloopBackend("claude", { hasAnthropicKey: true }), "anthropic");
+  assert.equal(resolveAutoloopBackend("anthropic", { hasAnthropicKey: false, hasOpenAiKey: true }), "");
   assert.equal(resolveAutoloopBackend("openai", { hasOpenAiKey: true, hasCodex: true }), "openai");
   assert.equal(resolveAutoloopBackend("codex", { hasOpenAiKey: true, hasCodex: true }), "codex");
   assert.equal(resolveAutoloopBackend("codex", { hasOpenAiKey: true, hasCodex: false }), "");
@@ -624,6 +636,29 @@ test("resolveAutoloopBackend respects explicit backend requests", () => {
     () => resolveAutoloopBackend("mystery", { hasOpenAiKey: true, hasCodex: true }),
     /Unknown autoloop backend/,
   );
+});
+
+test("extractAnthropicResponseText concatenates text blocks", () => {
+  const response = {
+    content: [
+      { type: "text", text: "one" },
+      { type: "thinking", thinking: "ignored" },
+      { type: "text", text: "two" },
+    ],
+  };
+  assert.equal(extractAnthropicResponseText(response), "one\ntwo");
+  assert.equal(extractAnthropicResponseText({}), "");
+});
+
+test("buildAnthropicApiError marks auth and billing failures as skippable", () => {
+  const authErr = buildAnthropicApiError(401, { error: { type: "authentication_error", message: "bad key" } });
+  const billingErr = buildAnthropicApiError(400, {
+    error: { type: "invalid_request_error", message: "Your credit balance is too low" },
+  });
+  const overloadedErr = buildAnthropicApiError(529, { error: { type: "overloaded_error", message: "busy" } });
+  assert.equal(authErr.skipAutoloop, true);
+  assert.equal(billingErr.skipAutoloop, true);
+  assert.equal(overloadedErr.skipAutoloop, false);
 });
 
 test("parseLsRemoteBranchHead extracts the requested remote branch head", () => {


### PR DESCRIPTION
## What

Switches the Continuous Improvement auto-loop's default LLM provider to **Claude (Anthropic API)**, while keeping OpenAI and the Codex CLI as fallbacks.

In `auto` mode (the default) the backend now resolves in this order:
1. **Anthropic** — when `ANTHROPIC_API_KEY` is set
2. **OpenAI** — when `OPENAI_API_KEY` is set
3. **Codex CLI** — when the `codex` binary is on PATH

`AUTOLOOP_BACKEND` can pin a provider explicitly (`anthropic`/`claude`, `openai`, `codex`).

## How

- **`scripts/autoloop-lib.mjs`** — `resolveAutoloopBackend()` takes `hasAnthropicKey` and prefers `anthropic` in `auto`; accepts explicit `anthropic`/`claude`. New `extractAnthropicResponseText()` and `buildAnthropicApiError()` helpers (the latter flags auth/billing failures as `skipAutoloop`, mirroring the OpenAI one).
- **`scripts/autoloop.mjs`** — `callModelJson()` dispatches to a new `callModelJsonViaAnthropic()` that POSTs to `/v1/messages` with `x-api-key`/`anthropic-version` headers, a JSON-only system prompt, and an assistant-prefill `{` to force a clean JSON object. All planner/patch-plan calls funnel through `callModelJson`, so every model interaction now goes through Claude. New config: `ANTHROPIC_BASE_URL`, `ANTHROPIC_MODEL` (default `claude-opus-4-8`), `ANTHROPIC_VERSION`. `AUTOLOOP_MODEL` still overrides the active backend's model.
- **`scripts/autoloop-forever.mjs`** — preflight + skip messages recognize `ANTHROPIC_API_KEY`.
- **CI / docs** — `.github/workflows/autoloop.yml` passes `secrets.ANTHROPIC_API_KEY` and only skips when both keys are absent; `.env.example`, `docs/ai-workflow.md`, `AGENTS.md` updated.
- **Tests** — extended backend-precedence coverage and added tests for the two new helpers. All 56 autoloop tests pass.

## Activation

Set `ANTHROPIC_API_KEY` locally (in `.env`) or as a repo secret for the GitHub-hosted loop. With `AUTOLOOP_BACKEND=auto` it automatically prefers Claude.

🤖 Generated with [Claude Code](https://claude.com/claude-code)