### PR TITLE
fix(autoloop): drop deprecated 'temperature' from Anthropic + OpenAI calls

### DIFF
--- a/scripts/autoloop.mjs
+++ b/scripts/autoloop.mjs
@@ -1253,7 +1253,10 @@ async function callModelJson({ prompt, maxOutputTokens = 4000, timeoutMs = CODEX
         "Return JSON only. The word JSON must appear in the output context, and the final output must be a single valid JSON object with no markdown fences.",
       input: prompt,
       text: { format: { type: "json_object" } },
-      temperature: 0.2,
+      // 'temperature' is deprecated/rejected for newer OpenAI Responses-API
+      // reasoning models (gpt-5.x family). The JSON-only contract above plus
+      // structured output is already deterministic enough; rely on the model
+      // default rather than 400ing on every call.
       max_output_tokens: maxOutputTokens,
       store: false,
     }),
@@ -1277,7 +1280,9 @@ async function callModelJsonViaAnthropic({ prompt, maxOutputTokens }) {
     body: JSON.stringify({
       model: ANTHROPIC_MODEL,
       max_tokens: maxOutputTokens,
-      temperature: 0.2,
+      // 'temperature' is deprecated/rejected for newer Anthropic models
+      // (Claude Opus 4.5+). Rely on the model default; the JSON-only
+      // system prompt + assistant prefill below is already deterministic.
       system:
         "Return JSON only. The final output must be a single valid JSON object with no markdown fences and no surrounding prose.",
       messages: [


### PR DESCRIPTION
The autoloop has been crashing on every invocation for 15+ hours with:

```
Anthropic API request failed (400): 'temperature' is deprecated for this model.
```

Newer reasoning models (Anthropic Claude Opus 4.5+, OpenAI gpt-5.x via the Responses API) reject `temperature` outright. The autoloop hard-codes `temperature: 0.2` for both providers, so every self-healing run died before it could even propose a fix -- which is why the f4a59336 CI failure sat broken for 14+ hours (see #130, #131 for the manual cleanup that should have been automated).

Drop the parameter from both providers. JSON-only system prompt + assistant `{` prefill (Anthropic) and `json_object` structured output (OpenAI) already provide deterministic-enough output for the autoloop's fix-proposal protocol.

## Verification
```
node --test test/autoloop.test.mjs
# ℹ pass 56  fail 0
```