### PR TITLE
fix(ci): per-app Fly deploy tokens for backend + frontend

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,6 +128,7 @@ jobs:
         if: steps.setup_flyctl.outputs.installed == 'true'
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+          FLY_API_TOKEN_FRONTEND: ${{ secrets.FLY_API_TOKEN_FRONTEND }}
           BACKEND_FLY_APP: ${{ secrets.FLY_APP }}
           FRONTEND_FLY_APP: ${{ secrets.FLY_FRONTEND_APP }}
         run: |
@@ -156,6 +157,7 @@ jobs:
             local workdir="$2"
             local config_path="$3"
             local app_name="$4"
+            local token_override="${5:-}"
             local config_basename
 
             if [[ ! -f "$config_path" ]]; then
@@ -171,9 +173,20 @@ jobs:
               deploy_args+=(--app "$app_name")
             fi
 
+            # Per-deploy token override: Fly app-scoped deploy tokens
+            # only carry a discharge for a single app, but we need to
+            # deploy two (backend + frontend). Pass a per-call override
+            # so each deploy sees the token authorized for that app.
+            local token_env=()
+            if [[ -n "$token_override" ]]; then
+              token_env=(env -u FLY_APP "FLY_API_TOKEN=${token_override}")
+            else
+              token_env=(env -u FLY_APP)
+            fi
+
             for attempt in 1 2 3; do
               : > "$deploy_log"
-              if env -u FLY_APP flyctl "${deploy_args[@]}" 2>&1 | tee "$deploy_log"; then
+              if "${token_env[@]}" flyctl "${deploy_args[@]}" 2>&1 | tee "$deploy_log"; then
                 popd >/dev/null
                 return 0
               fi
@@ -204,5 +217,9 @@ jobs:
             popd >/dev/null
           }
 
-          deploy_with_retries "backend" "." "fly.toml" "${BACKEND_FLY_APP:-}"
-          deploy_with_retries "frontend" "haskell/web" "haskell/web/fly.frontend.toml" "${FRONTEND_FLY_APP:-}"
+          deploy_with_retries "backend" "." "fly.toml" "${BACKEND_FLY_APP:-}" "${FLY_API_TOKEN}"
+          # If a frontend-specific token is configured (recommended,
+          # because Fly app-scoped deploy tokens carry a discharge for
+          # only one app), use it; otherwise fall back to the primary
+          # FLY_API_TOKEN and rely on org-level authorization.
+          deploy_with_retries "frontend" "haskell/web" "haskell/web/fly.frontend.toml" "${FRONTEND_FLY_APP:-}" "${FLY_API_TOKEN_FRONTEND:-${FLY_API_TOKEN}}"


### PR DESCRIPTION
## Why

Fly app-scoped deploy tokens (the kind 'flyctl auth whoami' will accept) only carry a third-party discharge for **a single app**. The CI workflow deploys two -- `trader-hs` (backend) and `trader-web-hs` (frontend) -- so a single `FLY_API_TOKEN` secret can authorize only one of them, and the other deploy step trips the 'missing third-party discharge token' guard and gets skipped. That's why every `main` CI run for the past few months has shown `Deploy (Fly.io): FLY_API_TOKEN is invalid for CI deploy (missing Fly discharge token)`.

## What

Refactor `deploy_with_retries` to accept an optional per-call token override, then:

- backend deploy → `FLY_API_TOKEN` (now an app-scoped token for `trader-hs`)
- frontend deploy → `FLY_API_TOKEN_FRONTEND` if set, else fall back to `FLY_API_TOKEN`

Secrets pushed alongside this PR:

- `FLY_API_TOKEN` rotated to a fresh `fly tokens create deploy -a trader-hs -x 8760h` token
- `FLY_API_TOKEN_FRONTEND` added (`fly tokens create deploy -a trader-web-hs -x 8760h`)

Both tokens have 1-year expiry rather than the Fly default of 20 years.

## Validation
After merge, the Deploy (Fly.io) job should actually run instead of skipping. Will watch the next `main` CI run.