### PR TITLE
fix(autoloop+web): drop Anthropic assistant prefill; pin react-dom 19.2.7

### DIFF
--- a/haskell/web/package-lock.json
+++ b/haskell/web/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "react": "19.2.7",
-        "react-dom": "19.2.6"
+        "react-dom": "19.2.7"
       },
       "devDependencies": {
         "@types/react": "^19.2.16",
@@ -1276,15 +1276,15 @@
       }
     },
     "node_modules/react-dom": {
-      "version": "19.2.6",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.6.tgz",
-      "integrity": "sha512-0prMI+hvBbPjsWnxDLxlCGyM8PN6UuWjEUCYmZhO67xIV9Xasa/r/vDnq+Xyq4Lo27g8QSbO5YzARu0D1Sps3g==",
+      "version": "19.2.7",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.7.tgz",
+      "integrity": "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==",
       "license": "MIT",
       "dependencies": {
         "scheduler": "^0.27.0"
       },
       "peerDependencies": {
-        "react": "^19.2.6"
+        "react": "^19.2.7"
       }
     },
     "node_modules/rolldown": {

--- a/haskell/web/package.json
+++ b/haskell/web/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "react": "19.2.7",
-    "react-dom": "19.2.6"
+    "react-dom": "19.2.7"
   },
   "devDependencies": {
     "@types/react": "^19.2.16",

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,8 +16,8 @@
       "name": "trader-web",
       "version": "0.1.0",
       "dependencies": {
-        "react": "19.2.4",
-        "react-dom": "19.2.4"
+        "react": "19.2.7",
+        "react-dom": "19.2.7"
       },
       "devDependencies": {
         "@types/react": "^19.2.14",
@@ -704,20 +704,20 @@
       }
     },
     "haskell/web/node_modules/react": {
-      "version": "19.2.4",
+      "version": "19.2.7",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "haskell/web/node_modules/react-dom": {
-      "version": "19.2.4",
+      "version": "19.2.7",
       "license": "MIT",
       "dependencies": {
         "scheduler": "^0.27.0"
       },
       "peerDependencies": {
-        "react": "^19.2.4"
+        "react": "^19.2.7"
       }
     },
     "haskell/web/node_modules/react-refresh": {

--- a/scripts/autoloop-lib.mjs
+++ b/scripts/autoloop-lib.mjs
@@ -35,8 +35,49 @@ export function parseJsonResponse(raw) {
   try {
     return JSON.parse(text);
   } catch (err) {
+    // Anthropic without assistant prefill can emit a stray leading/trailing
+    // line. Fall back to extracting the first balanced JSON object.
+    const extracted = extractFirstJsonObject(text);
+    if (extracted) {
+      try {
+        return JSON.parse(extracted);
+      } catch {
+        // fall through to original error
+      }
+    }
     throw new Error(`Model returned invalid JSON: ${err instanceof Error ? err.message : String(err)}`);
   }
+}
+
+function extractFirstJsonObject(text) {
+  const start = text.indexOf("{");
+  if (start === -1) return "";
+  let depth = 0;
+  let inString = false;
+  let escape = false;
+  for (let i = start; i < text.length; i++) {
+    const ch = text[i];
+    if (inString) {
+      if (escape) {
+        escape = false;
+      } else if (ch === "\\") {
+        escape = true;
+      } else if (ch === '"') {
+        inString = false;
+      }
+      continue;
+    }
+    if (ch === '"') {
+      inString = true;
+      continue;
+    }
+    if (ch === "{") depth++;
+    else if (ch === "}") {
+      depth--;
+      if (depth === 0) return text.slice(start, i + 1);
+    }
+  }
+  return "";
 }
 
 function extractCodexEventMessageText(item) {

--- a/scripts/autoloop.mjs
+++ b/scripts/autoloop.mjs
@@ -1282,13 +1282,13 @@ async function callModelJsonViaAnthropic({ prompt, maxOutputTokens }) {
       max_tokens: maxOutputTokens,
       // 'temperature' is deprecated/rejected for newer Anthropic models
       // (Claude Opus 4.5+). Rely on the model default; the JSON-only
-      // system prompt + assistant prefill below is already deterministic.
+      // system prompt is the contract — newer Anthropic models reject
+      // assistant-message prefill with HTTP 400, so we no longer end the
+      // conversation with an assistant turn.
       system:
-        "Return JSON only. The final output must be a single valid JSON object with no markdown fences and no surrounding prose.",
+        "Return JSON only. The final output must be a single valid JSON object that starts with '{' and ends with '}', with no markdown fences and no surrounding prose. Do not include any text before or after the JSON object.",
       messages: [
         { role: "user", content: prompt },
-        // Prefill the assistant turn with an opening brace so the model is forced to emit a JSON object.
-        { role: "assistant", content: "{" },
       ],
     }),
   });
@@ -1297,8 +1297,7 @@ async function callModelJsonViaAnthropic({ prompt, maxOutputTokens }) {
   if (!response.ok) {
     throw buildAnthropicApiError(response.status, json);
   }
-  // The prefilled "{" is not echoed back in the response, so restore it before parsing.
-  return parseJsonResponse(`{${extractAnthropicResponseText(json)}`);
+  return parseJsonResponse(extractAnthropicResponseText(json));
 }
 
 async function callModelJsonViaCodex({ prompt, maxOutputTokens, timeoutMs }) {

--- a/test/autoloop.test.mjs
+++ b/test/autoloop.test.mjs
@@ -224,6 +224,16 @@ test("parseJsonResponse rejects invalid JSON", () => {
   assert.throws(() => parseJsonResponse("not-json"), /invalid JSON/);
 });
 
+test("parseJsonResponse extracts first JSON object when model emits a stray preamble", () => {
+  // Newer Anthropic models (e.g. claude-opus-4-8) reject assistant-message
+  // prefill, so we can no longer force the response to start with '{'. The
+  // parser must tolerate optional whitespace, prose, or a leading newline
+  // before the JSON object.
+  assert.deepEqual(parseJsonResponse('Sure, here is the result:\n{"ok":true}'), { ok: true });
+  assert.deepEqual(parseJsonResponse('  \n {"noChange": false, "title": "x"}  \n'), { noChange: false, title: "x" });
+  assert.deepEqual(parseJsonResponse('```json\n{"a":1}\n```'), { a: 1 });
+});
+
 test("sanitizeRelativePath rejects absolute and traversal paths", () => {
   assert.equal(sanitizeRelativePath("./haskell/web/src/App.tsx"), "haskell/web/src/App.tsx");
   assert.equal(sanitizeRelativePath("haskell/web/src/./App.tsx"), "haskell/web/src/App.tsx");


### PR DESCRIPTION
## Why

Two simultaneous failures kept main red for >13h with zero autoloop healing:

1. **Autoloop crashed before proposing any fix** on every other cron tick:
   ```
   Anthropic API request failed (400): This model does not support
   assistant message prefill. The conversation must end with a user message.
   ```
   Newer Anthropic models (`claude-opus-4-8` et al.) reject the
   `{role:'assistant', content:'{'}` prefill we used to coerce a JSON-only
   reply.

2. **CI test `repo contract pins React runtime packages together`** failed because
   `react` was bumped to `19.2.7` while `react-dom` stayed at `19.2.6`.

## What

- `scripts/autoloop.mjs`: drop the trailing assistant prefill; rely on the
  system prompt that constrains the response to a JSON object.
- `scripts/autoloop-lib.mjs`: `parseJsonResponse` now falls back to extracting
  the first balanced JSON object so a stray preamble from the model doesn't
  break the parser.
- `test/autoloop.test.mjs`: new coverage for the preamble-tolerant parser.
- `haskell/web/package.json` + `haskell/web/package-lock.json` + root
  `package-lock.json` (workspace entry): `react-dom` → `19.2.7` to match `react`.

## Verification

- `node --test test/autoloop.test.mjs` → 57/57 pass
- `bash scripts/verify.sh web` → 196/196 pass + clean build

## Follow-ups (no action required from this PR)

Once merged, the next scheduled Autoloop tick should run clean. If it still
finds something on `main`, it'll self-propose a fix as designed.