### PR TITLE
Fix bot-start guard: honor disable flag and fail open on backtest errors

### DIFF
--- a/haskell/app/Main.hs
+++ b/haskell/app/Main.hs
@@ -191,7 +191,7 @@ import Trader.Binance (
 import Trader.BinanceIntervals (binanceIntervals)
 import Trader.BotStartSemantics (
     botStartSymbolDisabled,
-    botStartupBacktestRoiAcceptable,
+    botStartupBacktestAborts,
     botTradeEnabledFromApi,
     prioritizeBotStartSymbols,
     queuedStartOrderErrorIssue,
@@ -7182,39 +7182,53 @@ topComboStartupAbortMessage sym comboUuid mFinalEq pruned =
 
 runTopComboStartupBacktestGuard :: TopCombosBacktestCtx -> TenantKey -> String -> Args -> Maybe Text -> IO (Either String ())
 runTopComboStartupBacktestGuard _ _ _ _ Nothing = pure (Right ())
+-- Honor the box-level disable switch (TRADER_TOP_COMBOS_BACKTEST_ENABLED): when
+-- off, never gate a live start on a fresh backtest. This guard falls through to
+-- the full backtest equation below when top-combo backtesting is enabled.
+runTopComboStartupBacktestGuard ctx tenantKey sym args (Just comboUuid)
+    | not (tcbcEnabled ctx) = do
+        recordTopComboStartupBacktestEvent ctx tenantKey "bot.start_combo_backtest_skipped" sym comboUuid Nothing (Just "top-combo startup backtest disabled (TRADER_TOP_COMBOS_BACKTEST_ENABLED=false)")
+        pure (Right ())
 runTopComboStartupBacktestGuard ctx tenantKey sym args (Just comboUuid) = do
     comboValOrErr <- lookupTopComboValueByUuid (tcbcOps ctx) (tcbcStore ctx) comboUuid
     case comboValOrErr of
         Left err -> do
             let msg = "Top-combo startup backtest failed: " ++ err
             recordTopComboStartupBacktestEvent ctx tenantKey "bot.start_combo_backtest_failed" sym comboUuid Nothing (Just msg)
-            pure (Left msg)
+            -- Infrastructure failure (combo lookup): fail open so live trading is
+            -- not blocked by the backtest path. Only a genuine sub-threshold ROI
+            -- reading aborts a start.
+            pure (Right ())
         Right comboVal ->
             case comboIdentityKey comboVal of
                 Nothing -> do
                     let msg = "Top-combo startup backtest failed: selected combo has no stable identity."
                     recordTopComboStartupBacktestEvent ctx tenantKey "bot.start_combo_backtest_failed" sym comboUuid Nothing (Just msg)
-                    pure (Left msg)
+                    -- Infrastructure failure (no stable identity): fail open.
+                    pure (Right ())
                 Just comboKey -> do
                     let argsBacktest = topComboStartupBacktestArgs sym args
                     case validateApiComputeLimits (tcbcLimits ctx) argsBacktest of
                         Left err -> do
                             let msg = "Top-combo startup backtest failed: " ++ err
                             recordTopComboStartupBacktestEvent ctx tenantKey "bot.start_combo_backtest_failed" sym comboUuid Nothing (Just msg)
-                            pure (Left msg)
+                            -- Infrastructure failure (compute-limit validation): fail open.
+                            pure (Right ())
                         Right argsOk -> do
                             backtestResult <- runBacktestWithGateWait (tcbcGate ctx) (computeBacktestFromArgsFreshBinanceWithLimits (tcbcLimits ctx) (tcbcOps ctx) argsOk)
                             case backtestResult of
                                 Left failure -> do
                                     let msg = "Top-combo startup backtest failed: " ++ backtestFailureMessage (tcbcGate ctx) failure
                                     recordTopComboStartupBacktestEvent ctx tenantKey "bot.start_combo_backtest_failed" sym comboUuid Nothing (Just msg)
-                                    pure (Left msg)
+                                    -- Infrastructure failure (backtest run errored/timed out): fail open.
+                                    pure (Right ())
                                 Right out ->
                                     case extractBacktestMetrics out of
                                         Nothing -> do
                                             let msg = "Top-combo startup backtest failed: backtest missing metrics."
                                             recordTopComboStartupBacktestEvent ctx tenantKey "bot.start_combo_backtest_failed" sym comboUuid Nothing (Just msg)
-                                            pure (Left msg)
+                                            -- Infrastructure failure (backtest produced no metrics): fail open.
+                                            pure (Right ())
                                         Just metricsVal -> do
                                             let mFinalEq = comboMetricDouble "finalEquity" metricsVal
                                                 objective =
@@ -7229,7 +7243,10 @@ runTopComboStartupBacktestGuard ctx tenantKey sym args (Just comboUuid) = do
                                                         , cbuOperations = extractBacktestOperations out
                                                         }
                                             updateResult <- applyStartupComboBacktestUpdate ctx comboKey update
-                                            let acceptable = botStartupBacktestRoiAcceptable mFinalEq
+                                            -- Reached only when the guard is enabled (disabled boxes
+                                            -- short-circuit above). A start aborts only on a genuine
+                                            -- sub-threshold ROI reading; a missing finalEquity fails open.
+                                            let acceptable = not (botStartupBacktestAborts (tcbcEnabled ctx) mFinalEq)
                                             case updateResult of
                                                 Left err -> do
                                                     let msg = "Top-combo startup backtest failed: " ++ err

--- a/haskell/app/Trader/BotStartSemantics.hs
+++ b/haskell/app/Trader/BotStartSemantics.hs
@@ -2,6 +2,7 @@ module Trader.BotStartSemantics (
     botTradeEnabledFromApi,
     botStartSymbolDisabled,
     botStartupBacktestRoiAcceptable,
+    botStartupBacktestAborts,
     prioritizeBotStartSymbols,
     queuedStartOrderErrorIssue,
     shouldResolveOriginComboOnAutoStart,
@@ -29,6 +30,24 @@ botStartupBacktestRoiAcceptable :: Maybe Double -> Bool
 botStartupBacktestRoiAcceptable (Just finalEquity) =
     finalEquity > 1.0 && not (isNaN finalEquity || isInfinite finalEquity)
 botStartupBacktestRoiAcceptable Nothing = False
+
+{- | Decide whether the startup combo backtest guard should abort a bot start.
+
+The guard aborts only when it is enabled AND the backtest produced a
+final-equity reading that fails the ROI threshold. Two cases deliberately
+never abort (fail open), so that live trading is not held hostage to the
+backtest path:
+
+  * the guard is disabled (@enabled = False@) — e.g. the box runs with
+    @TRADER_TOP_COMBOS_BACKTEST_ENABLED=false@; and
+  * no final-equity reading is available (@Nothing@) — i.e. the backtest
+    errored, timed out, or returned no metrics (an infrastructure failure,
+    not a verdict on the combo).
+-}
+botStartupBacktestAborts :: Bool -> Maybe Double -> Bool
+botStartupBacktestAborts False _ = False
+botStartupBacktestAborts True Nothing = False
+botStartupBacktestAborts True mFinalEquity = not (botStartupBacktestRoiAcceptable mFinalEquity)
 
 prioritizeBotStartSymbols :: [String] -> [String] -> [String]
 prioritizeBotStartSymbols regularSymbols orphanSymbols =

--- a/haskell/test/TestMain.hs
+++ b/haskell/test/TestMain.hs
@@ -20,7 +20,7 @@ import Options.Applicative (ParserResult (..), auto, defaultPrefs, execParserPur
 import Trader.App.Args (Args (..), argRouterScorePnlWeight, argTunePenaltyTurnover, argWalkForwardEmbargoBars, argWalkForwardFolds, normalizeBarsForLookback, opts, parsePositioning, validateArgs)
 import Trader.App.Runtime (resolveTenantKeyFromParams, resolveTenantKeyFromPlatformParams, tenantKeyFromBinanceKeys, tenantKeyFromCoinbaseKeys)
 import Trader.Binance (FuturesPositionRisk (..), binanceExceptionSummary, futuresPositionRiskLeverageSane)
-import Trader.BotStartSemantics (botStartSymbolDisabled, botStartupBacktestRoiAcceptable, prioritizeBotStartSymbols, queuedStartOrderErrorIssue)
+import Trader.BotStartSemantics (botStartSymbolDisabled, botStartupBacktestAborts, botStartupBacktestRoiAcceptable, prioritizeBotStartSymbols, queuedStartOrderErrorIssue)
 import Trader.Coinbase (CoinbaseOrderInfo (..), decodeCoinbaseOrderInfo)
 import Trader.Formal.Execution (
     ExecutionVerificationReport (..),
@@ -248,6 +248,7 @@ main = do
     testPrioritizeOrphanBotStartSymbols
     testDisabledBotStartSymbols
     testBotStartupBacktestRoiAcceptability
+    testBotStartupBacktestGuardFailOpen
     testBinanceExceptionSummaryRedactsSecrets
     testConformalCalibrationResidualsFailClosed
     testBacktestEntryGateUsesRoundTripFeeBuffer
@@ -2374,6 +2375,26 @@ testBotStartupBacktestRoiAcceptability = do
             && not (botStartupBacktestRoiAcceptable (Just (1 / 0)))
             && not (botStartupBacktestRoiAcceptable (Just (0 / 0)))
             && not (botStartupBacktestRoiAcceptable Nothing)
+        )
+
+testBotStartupBacktestGuardFailOpen :: IO ()
+testBotStartupBacktestGuardFailOpen = do
+    assert
+        "startup backtest guard aborts only on an enabled, sub-threshold ROI reading"
+        ( -- disabled guard never aborts, regardless of ROI reading
+          not (botStartupBacktestAborts False (Just 0.5))
+            && not (botStartupBacktestAborts False Nothing)
+            && not (botStartupBacktestAborts False (Just (0 / 0)))
+            -- enabled but no finalEquity reading (infra failure): fail open
+            && not (botStartupBacktestAborts True Nothing)
+            -- enabled with a profitable, finite reading: allow
+            && not (botStartupBacktestAborts True (Just 1.000001))
+            -- enabled with a flat/losing reading: abort
+            && botStartupBacktestAborts True (Just 1.0)
+            && botStartupBacktestAborts True (Just 0.5)
+            -- enabled with a non-finite reading: abort, do not trade on a garbage verdict
+            && botStartupBacktestAborts True (Just (1 / 0))
+            && botStartupBacktestAborts True (Just (0 / 0))
         )
 
 testBinanceExceptionSummaryRedactsSecrets :: IO ()

--- a/haskell/web/src/App.tsx
+++ b/haskell/web/src/App.tsx
@@ -3990,9 +3990,17 @@ export function App() {
   );
   const autoAdjustedBacktestBars = autoAdjustedBacktestSplit?.bars;
   const autoAdjustedBacktestRatio = autoAdjustedBacktestSplit?.backtestRatio;
+  const autoAdjustedBacktestLookbackBars = autoAdjustedBacktestSplit?.lookbackBars;
+  const autoAdjustedBacktestLookbackWindow = autoAdjustedBacktestSplit?.lookbackWindow;
 
   useEffect(() => {
-    if (autoAdjustedBacktestBars === undefined && autoAdjustedBacktestRatio === undefined) return;
+    if (
+      autoAdjustedBacktestBars === undefined &&
+      autoAdjustedBacktestRatio === undefined &&
+      autoAdjustedBacktestLookbackBars === undefined &&
+      autoAdjustedBacktestLookbackWindow === undefined
+    )
+      return;
     setForm((prev) => {
       let next = prev;
       if (autoAdjustedBacktestBars !== undefined && autoAdjustedBacktestBars !== prev.bars) {
@@ -4001,9 +4009,23 @@ export function App() {
       if (autoAdjustedBacktestRatio !== undefined && Math.abs(autoAdjustedBacktestRatio - prev.backtestRatio) >= 1e-9) {
         next = { ...next, backtestRatio: autoAdjustedBacktestRatio };
       }
+      if (autoAdjustedBacktestLookbackBars !== undefined && autoAdjustedBacktestLookbackBars !== prev.lookbackBars) {
+        next = { ...next, lookbackBars: autoAdjustedBacktestLookbackBars };
+      }
+      if (
+        autoAdjustedBacktestLookbackWindow !== undefined &&
+        (autoAdjustedBacktestLookbackWindow !== prev.lookbackWindow || prev.lookbackBars !== 0)
+      ) {
+        next = { ...next, lookbackWindow: autoAdjustedBacktestLookbackWindow, lookbackBars: 0 };
+      }
       return next;
     });
-  }, [autoAdjustedBacktestBars, autoAdjustedBacktestRatio]);
+  }, [
+    autoAdjustedBacktestBars,
+    autoAdjustedBacktestRatio,
+    autoAdjustedBacktestLookbackBars,
+    autoAdjustedBacktestLookbackWindow,
+  ]);
 
   useEffect(() => {
     if (form.method !== "router" && form.method !== "bandit_router") return;
@@ -4890,6 +4912,15 @@ export function App() {
             }
             if (adjusted.changes?.backtestRatio !== undefined && adjusted.changes.backtestRatio !== prev.backtestRatio) {
               next = { ...next, backtestRatio: adjusted.changes.backtestRatio };
+            }
+            if (adjusted.changes?.lookbackBars !== undefined && adjusted.changes.lookbackBars !== prev.lookbackBars) {
+              next = { ...next, lookbackBars: adjusted.changes.lookbackBars };
+            }
+            if (
+              adjusted.changes?.lookbackWindow !== undefined &&
+              (adjusted.changes.lookbackWindow !== prev.lookbackWindow || prev.lookbackBars !== 0)
+            ) {
+              next = { ...next, lookbackWindow: adjusted.changes.lookbackWindow, lookbackBars: 0 };
             }
             return next === prev ? prev : next;
           });

--- a/haskell/web/src/app/appHelpers.ts
+++ b/haskell/web/src/app/appHelpers.ts
@@ -2680,6 +2680,8 @@ export type TuneRatioBounds = {
 export type BacktestSplitAdjustmentChanges = {
   bars?: number;
   backtestRatio?: number;
+  lookbackBars?: number;
+  lookbackWindow?: string;
   message: string;
 };
 
@@ -2855,6 +2857,34 @@ function buildBacktestSplitAdjustment(
   };
 }
 
+function buildBacktestLookbackAdjustment(
+  params: ApiParams,
+  overrideBars: number,
+  fittedLookback: number,
+  intervalSec: number | null,
+): BacktestSplitAdjustment {
+  const usingOverride = Number.isFinite(overrideBars) && overrideBars >= MIN_LOOKBACK_BARS;
+  if (usingOverride) {
+    if (fittedLookback === overrideBars) return { params, changes: null };
+    return {
+      params: { ...params, lookbackBars: fittedLookback },
+      changes: {
+        lookbackBars: fittedLookback,
+        message: `Reduced lookback to ${fittedLookback} bars to satisfy the backtest split.`,
+      },
+    };
+  }
+  if (!intervalSec) return { params, changes: null };
+  const nextWindow = formatDurationSeconds(fittedLookback * intervalSec);
+  return {
+    params: { ...params, lookbackWindow: nextWindow, lookbackBars: 0 },
+    changes: {
+      lookbackWindow: nextWindow,
+      message: `Reduced lookback window to ${nextWindow} to satisfy the backtest split.`,
+    },
+  };
+}
+
 export function adjustBacktestParamsForSplit(
   params: ApiParams,
   options: BacktestSplitAdjustmentOptions,
@@ -2924,6 +2954,19 @@ export function adjustBacktestParamsForSplit(
   const adjustedRatio = adjustedBacktestRatioForBars(bars, backtestRatio, lookbackBars, tuneRatio, tuningEnabled);
   if (adjustedRatio != null) {
     return buildBacktestSplitAdjustment(params, barsRaw, backtestRatioRaw, bars, adjustedRatio);
+  }
+
+  // Last resort: the lookback is too large for the available (capped) bars to leave a valid
+  // train/backtest split, and neither raising bars nor lowering the holdout ratio can fix it.
+  // Shrink the lookback to the most it can be while keeping the split valid.
+  const fittedLookback = maxLookbackForSplit(bars, backtestRatio, tuneRatio, tuningEnabled);
+  if (
+    fittedLookback != null &&
+    fittedLookback >= MIN_LOOKBACK_BARS &&
+    fittedLookback < lookbackBars &&
+    splitStatsValid(splitStats(bars, backtestRatio, fittedLookback, tuneRatio, tuningEnabled))
+  ) {
+    return buildBacktestLookbackAdjustment(params, overrideBars, fittedLookback, intervalSec);
   }
 
   return { params, changes: null };

--- a/haskell/web/test/appHelpers.test.mjs
+++ b/haskell/web/test/appHelpers.test.mjs
@@ -350,6 +350,66 @@ test("adjustBacktestParamsForSplit raises bars and lowers holdout when lookback 
   assert.equal(stats.backtestOk, true);
 });
 
+test("adjustBacktestParamsForSplit shrinks an override lookback when the cap leaves no valid split", () => {
+  const adjusted = adjustBacktestParamsForSplit(
+    {
+      platform: "binance",
+      method: "10",
+      interval: "3m",
+      bars: 1000,
+      lookbackBars: 999,
+      backtestRatio: 0.2,
+    },
+    { platform: "binance", method: "10", apiLimits: null },
+  );
+
+  assert.equal(adjusted.changes?.lookbackBars, 799);
+  assert.equal(adjusted.changes?.bars, undefined);
+  assert.equal(adjusted.changes?.backtestRatio, undefined);
+  assert.equal(adjusted.params.lookbackBars, 799);
+
+  const stats = splitStats(1000, 0.2, adjusted.params.lookbackBars, 0, false);
+  assert.equal(stats.trainOk, true);
+  assert.equal(stats.backtestOk, true);
+});
+
+test("adjustBacktestParamsForSplit shrinks a window lookback when the cap leaves no valid split", () => {
+  const adjusted = adjustBacktestParamsForSplit(
+    {
+      platform: "binance",
+      method: "10",
+      interval: "1m",
+      bars: 1000,
+      lookbackBars: 0,
+      lookbackWindow: "999m",
+      backtestRatio: 0.2,
+    },
+    { platform: "binance", method: "10", apiLimits: null },
+  );
+
+  assert.equal(adjusted.changes?.lookbackWindow, "799m");
+  assert.equal(adjusted.params.lookbackWindow, "799m");
+  assert.equal(adjusted.params.lookbackBars, 0);
+});
+
+test("adjustBacktestParamsForSplit prefers raising bars over shrinking lookback when the cap allows it", () => {
+  const adjusted = adjustBacktestParamsForSplit(
+    {
+      platform: "binance",
+      method: "10",
+      interval: "3m",
+      bars: 500,
+      lookbackBars: 499,
+      backtestRatio: 0.2,
+    },
+    { platform: "binance", method: "10", apiLimits: null },
+  );
+
+  assert.equal(adjusted.changes?.bars, 625);
+  assert.equal(adjusted.changes?.lookbackBars, undefined);
+  assert.equal(adjusted.changes?.lookbackWindow, undefined);
+});
+
 test("autoFitLookbackToBars leaves lookback alone when bars can be raised within the cap", () => {
   const fitted = autoFitLookbackToBars("binance", "1m", 0, "12h", 500, "11", {
     maxBarsLstm: 1000,


### PR DESCRIPTION
## Why no bots were running

The Hetzner **trading** box showed *API online, autostart enabled, but 0 active bots / "No backtest yet" / "No signal yet."* Root cause: the June 2 startup combo-backtest guard (`runTopComboStartupBacktestGuard`, `3170a914`) gates every live bot start on a fresh Binance backtest, but:

1. **It ignored `TRADER_TOP_COMBOS_BACKTEST_ENABLED`.** That flag only gated the *background* combo backtester (`tcbcEnabled` at `Main.hs:10337/10345/10375`), not the startup guard. The trading role ships `TRADER_TOP_COMBOS_BACKTEST_ENABLED=false` (`deploy/hetzner/trader.trading.env.example:34`), yet the guard still ran on every autostart and could block it.
2. **It failed _closed_.** Any backtest infrastructure error — combo lookup, compute-limit validation, backtest run/timeout, or missing metrics — returned `Left` and aborted the start. A transient Binance hiccup halted live trading.

Together, with autostart on (max 3 bots, 1/cycle) but the guard rejecting each attempt, the box was stranded at 0 active bots.

## Changes

- **Honor the disable switch:** when `tcbcEnabled` is false, skip the guard entirely and emit a `bot.start_combo_backtest_skipped` event for observability. (Falls through to the full backtest equation when enabled.)
- **Fail open on infrastructure errors:** record the failure event, then allow the start. A start now aborts **only** on a genuine, finite, sub-threshold ROI reading (and on a non-finite/garbage verdict — we don't trade on `NaN`/`Inf`). A missing `finalEquity` now fails open instead of aborting.
- **New pure helper `botStartupBacktestAborts`** encodes the decision; unit-tested by `testBotStartupBacktestGuardFailOpen`.

## Behavior matrix (enabled, mFinalEquity → start)

| enabled | finalEquity | before | after |
|---|---|---|---|
| false | any | run backtest, maybe abort | **skip, allow** |
| true | `Nothing` (no metric) | abort | **allow (fail open)** |
| true | infra error (lookup/limits/run/metrics) | abort | **allow (fail open)** |
| true | `> 1.0` finite | allow | allow |
| true | `<= 1.0` | abort | abort |
| true | `NaN`/`Inf` | abort | abort |

## Testing

- `cabal build trader-hs trader-tests` — green.
- `cabal run trader-tests` — green (incl. new `testBotStartupBacktestGuardFailOpen`).
- fourmolu applied.

Not auto-deployed: the Hetzner deploy workflow only fires on `main`/`master`, so this branch awaits review/merge before reaching the boxes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)