### PR TITLE
Alpha-research harness + data-acquisition spec

### DIFF
--- a/data/research/.gitignore
+++ b/data/research/.gitignore
@@ -1,0 +1,6 @@
+# Generated research data cache (accumulated by scripts/research/datafeed.py).
+# Tracked dir, ignored contents.
+*.csv
+*.parquet
+*.feather
+!.gitignore

--- a/research-notes/data-acquisition-spec.md
+++ b/research-notes/data-acquisition-spec.md
@@ -1,0 +1,57 @@
+# Alpha-research data-acquisition spec
+
+**Date:** 2026-06-10
+**Why this exists:** every signal investigation so far (Kalman, method-mix, optimizer warm-start, exogenous funding/basis) looked promising in-sample and dissolved under honest out-of-sample testing. The binding constraint turned out not to be the model but the **data**: the Binance `/futures/data` stats endpoints return only ~30 days, so every OOS test ran on ~9–60 day windows where sharpe estimates are statistically meaningless (the harness's bootstrap CIs straddle zero — see `scripts/research/`). You cannot establish or refute an edge on that. This spec lists what to acquire so the harness has **years and thousands of trades**, not days.
+
+**Evaluation bar (enforced by `scripts/research/harness.py`):** a signal is only deployable if, on this data, it shows OOS sharpe whose bootstrap CI **excludes 0**, a deflated `P(SR>0) ≥ 0.95` after the multiple-testing haircut, consistency **across symbols**, and stability **across up/down regimes**. Target ≥ 1500 OOS observations minimum (years of daily, or months of hourly).
+
+---
+
+## Tier 0 — free, start accumulating immediately (no spend)
+
+| Dataset | Source | Fields | Granularity | History available | Notes |
+|---|---|---|---|---|---|
+| Perp OHLCV | Binance `/fapi/v1/klines` | O/H/L/C/V | 1m–1d | **full (years)** via pagination | already used; deep history is free |
+| Funding rate | Binance `/fapi/v1/fundingRate` | fundingRate, fundingTime | 8h | **full (years)** free | best free exogenous series; the funding IC was the most consistent signal |
+| Open interest | Binance `/futures/data/openInterestHist` | sumOpenInterest | 5m–1d | **~30 days only** | **must accumulate** (run `datafeed.update_cache` on cron) or buy archival |
+| Basis | Binance `/futures/data/basis` | basisRate | 5m–1d | **~30 days only** | same — accumulate or buy |
+| Taker buy/sell | Binance `/futures/data/takerlongshortRatio` | buySellRatio | 5m–1d | **~30 days only** | same |
+| Long/short ratios | Binance `/futures/data/global...Ratio`, `top...Ratio` | account/position ratios | 5m–1d | ~30 days | accumulate |
+
+**Action:** schedule `python3 scripts/research/datafeed.py <symbols>` (hourly/daily) so the 30-day-limited series build a permanent history in `data/research/`. Cost: $0; you just need to start now — every day not collecting is lost.
+
+## Tier 1 — paid archival (highest value; buys the history Tier 0 can't backfill)
+
+| Dataset | Vendors | Why it matters | Rough cost |
+|---|---|---|---|
+| Historical OI / basis / funding / liquidations (years) | **Tardis.dev**, Amberdata, Kaiko, CoinAPI | backfills the 30-day gap immediately → can test funding/basis edge over multiple regimes *today* instead of waiting months | ~$100–500/mo or per-dataset |
+| L2 order book + trades (tick) | **Tardis.dev** (best coverage), Kaiko | order-flow imbalance / microstructure — the highest-frequency edge, and raises trade count for statistical power | $$ (storage-heavy) |
+| Liquidation feed | Tardis, Coinglass API | cascade/reversal signal | $ |
+| On-chain | **Glassnode**, CryptoQuant, Nansen | exchange net-flows, stablecoin supply, whale/miner moves — daily-cadence, fits daily bars | ~$30–800/mo by tier |
+
+**Recommended first buy:** Tardis.dev historical funding + OI + basis + liquidations for the top ~10 perps, 2+ years. It's the cheapest way to turn the already-promising-but-unprovable funding/basis result into a verdict.
+
+## Tier 2 — macro / options (mostly free; regime context)
+
+| Dataset | Source | Use |
+|---|---|---|
+| DXY, US 2y/10y, real rates, net Fed liquidity (reserves−RRP−TGA) | **FRED** (free) | crypto is liquidity/risk-on driven; explains regime the per-coin model can't see |
+| Equities / VIX | Yahoo, Stooq (free) | risk-on/off |
+| Implied vol / DVOL term structure | Deribit (free API), Laevitas | regime detection; scales the Kalman Q/R adaptively |
+
+---
+
+## Storage & point-in-time discipline
+
+- **Schema:** one CSV per `(symbol, interval)` in `data/research/` — `openTime, open, high, low, close, volume, funding, oi, basis, taker, …`. Exogenous columns are stored **already point-in-time aligned** to bar close (`datafeed.align_pit`). Drop-in archival data must follow the same schema/alignment.
+- **Point-in-time is non-negotiable.** Every exogenous value must be lagged to when it was actually available (funding settles on a schedule; on-chain/macro publish with delay). Leakage here fabricates fake in-sample edge — which is exactly the trap this whole effort kept falling into.
+- **Survivorship:** include delisted/changed perps when buying archival, or cross-sectional tests are biased.
+
+## How this plugs into the harness
+
+`scripts/research/`:
+- `datafeed.py` — incremental cache + point-in-time alignment + `load_panel`.
+- `harness.py` — cost-aware walk-forward, **block-bootstrap sharpe CI**, **deflated `P(SR>0)`** (multiple-testing haircut), regime split, cross-sectional book.
+- `run_example.py` — runnable demo; today it correctly **flags small-sample unreliability** on the 30-day window.
+
+Once Tier-0 accumulation (or a Tier-1 buy) gives ≥ ~1500 clean OOS observations, re-run the harness. If funding/basis (or order-flow) clears the evaluation bar across symbols and regimes, *then* wire it into the trading system (the inert foundation is already merged: commit `e513c8d5`). If it doesn't clear the bar at that sample size, the edge isn't there and the strategy needs a different basis — but you'll know honestly, which is the entire point.

--- a/scripts/research/datafeed.py
+++ b/scripts/research/datafeed.py
@@ -27,7 +27,10 @@ import numpy as np
 import pandas as pd
 
 BASE = "https://fapi.binance.com"
-CACHE_DIR = os.path.abspath(
+# Cache location: override with TRADER_RESEARCH_CACHE (e.g. for a standalone
+# scheduled collector that must not depend on the repo checkout path), else
+# default to data/research/ in the repo.
+CACHE_DIR = os.environ.get("TRADER_RESEARCH_CACHE") or os.path.abspath(
     os.path.join(os.path.dirname(__file__), "..", "..", "data", "research")
 )
 INTERVAL_MS = {

--- a/scripts/research/datafeed.py
+++ b/scripts/research/datafeed.py
@@ -1,0 +1,192 @@
+"""Incremental, point-in-time data feed for the alpha-research harness.
+
+Fetches Binance USDT-perp OHLCV plus the free derivatives-stats series (funding,
+open interest, basis, taker buy/sell flow), caches them append-only under
+``data/research/``, and serves bar-aligned panels.
+
+Why a cache: the ``/futures/data`` stats endpoints only return ~30 days of
+history, which is far too short to establish or refute an edge (see
+``research-notes/data-acquisition-spec.md``). Running ``update_cache`` on a
+schedule accumulates history going forward so the harness eventually has
+months/years instead of days. The cache is also where you drop archival/paid
+history (same schema) when you acquire it.
+
+Dependencies: numpy, pandas, urllib (stdlib). No paid keys; all endpoints are
+public.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+import urllib.error
+import urllib.request
+
+import numpy as np
+import pandas as pd
+
+BASE = "https://fapi.binance.com"
+CACHE_DIR = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), "..", "..", "data", "research")
+)
+INTERVAL_MS = {
+    "5m": 300_000,
+    "15m": 900_000,
+    "30m": 1_800_000,
+    "1h": 3_600_000,
+    "2h": 7_200_000,
+    "4h": 14_400_000,
+    "6h": 21_600_000,
+    "12h": 43_200_000,
+    "1d": 86_400_000,
+}
+
+
+def _get(path: str, tries: int = 4, **params):
+    url = f"{BASE}{path}?" + "&".join(f"{k}={v}" for k, v in params.items())
+    for i in range(tries):
+        try:
+            with urllib.request.urlopen(url, timeout=30) as r:
+                return json.load(r)
+        except (urllib.error.URLError, TimeoutError) as e:  # transient — back off
+            if i == tries - 1:
+                raise
+            time.sleep(1.5 * (i + 1))
+    return []
+
+
+def fetch_klines(sym: str, interval: str, limit: int = 1500) -> pd.DataFrame:
+    """Closed klines, paginated past the 1000/req cap. Columns: openTime, open,
+    high, low, close, volume."""
+    out, end = [], None
+    ms = INTERVAL_MS[interval]
+    while len(out) < limit:
+        p = dict(symbol=sym, interval=interval, limit=min(1000, limit - len(out)))
+        if end is not None:
+            p["endTime"] = end
+        batch = _get("/fapi/v1/klines", **p)
+        if not batch:
+            break
+        out = batch + out
+        end = batch[0][0] - 1
+        if len(batch) < p["limit"]:
+            break
+    rows = [
+        (int(k[0]), float(k[1]), float(k[2]), float(k[3]), float(k[4]), float(k[5]))
+        for k in out
+    ]
+    df = pd.DataFrame(rows, columns=["openTime", "open", "high", "low", "close", "volume"])
+    df = df.drop_duplicates("openTime").sort_values("openTime").reset_index(drop=True)
+    # drop the still-forming last bar
+    now = time.time() * 1000
+    df = df[df["openTime"] + ms - 1 < now]
+    return df.reset_index(drop=True)
+
+
+def _stats(sym_or_pair_key: str, path: str, ts_key: str, val_key: str, **params):
+    time.sleep(0.3)  # gentle pacing to avoid /futures/data rate limits
+    rows = _get(path, **params)
+    if not isinstance(rows, list):  # error responses come back as a dict
+        return []
+    return [
+        (int(r[ts_key]), float(r[val_key]))
+        for r in rows
+        if isinstance(r, dict) and ts_key in r and val_key in r
+    ]
+
+
+def fetch_funding(sym, limit=1000):
+    return _stats(sym, "/fapi/v1/fundingRate", "fundingTime", "fundingRate", symbol=sym, limit=limit)
+
+
+def fetch_oi(sym, period, limit=500):
+    return _stats(sym, "/futures/data/openInterestHist", "timestamp", "sumOpenInterest", symbol=sym, period=period, limit=limit)
+
+
+def fetch_basis(sym, period, limit=500):
+    return _stats(sym, "/futures/data/basis", "timestamp", "basisRate", pair=sym, contractType="PERPETUAL", period=period, limit=limit)
+
+
+def fetch_taker(sym, period, limit=500):
+    return _stats(sym, "/futures/data/takerlongshortRatio", "timestamp", "buySellRatio", symbol=sym, period=period, limit=limit)
+
+
+def align_pit(bar_close: np.ndarray, series: list[tuple[int, float]]) -> np.ndarray:
+    """Point-in-time forward-fill: value at each bar is the latest observation
+    with timestamp <= that bar's CLOSE. No future obs can affect an earlier bar."""
+    series = sorted(series)
+    out = np.full(len(bar_close), np.nan)
+    j, last = 0, np.nan
+    for i, c in enumerate(bar_close):
+        while j < len(series) and series[j][0] <= c:
+            last = series[j][1]
+            j += 1
+        out[i] = last
+    return out
+
+
+def _cache_path(sym, interval):
+    return os.path.join(CACHE_DIR, f"{sym}_{interval}.csv")
+
+
+def update_cache(symbols, interval="1h", kline_limit=1500):
+    """Fetch the latest window for each symbol and merge (dedup by openTime) into
+    the append-only CSV cache. Stats columns are stored already point-in-time
+    aligned to the bars present at write time."""
+    os.makedirs(CACHE_DIR, exist_ok=True)
+    ms = INTERVAL_MS[interval]
+    period = interval if interval in {"5m", "15m", "30m", "1h", "2h", "4h", "6h", "12h", "1d"} else "1h"
+    for sym in symbols:
+        k = fetch_klines(sym, interval, kline_limit)
+        if k.empty:
+            print(f"  {sym}: no klines")
+            continue
+        bclose = (k["openTime"] + ms - 1).to_numpy()
+        try:
+            k["funding"] = align_pit(bclose, fetch_funding(sym))
+            k["oi"] = align_pit(bclose, fetch_oi(sym, period))
+            k["basis"] = align_pit(bclose, fetch_basis(sym, period))
+            k["taker"] = align_pit(bclose, fetch_taker(sym, period))
+        except Exception as e:  # stats are best-effort; OHLCV still cached
+            print(f"  {sym}: stats partial ({str(e)[:50]})")
+            for c in ("funding", "oi", "basis", "taker"):
+                if c not in k:
+                    k[c] = np.nan
+        path = _cache_path(sym, interval)
+        if os.path.exists(path):
+            old = pd.read_csv(path)
+            k = (
+                pd.concat([old, k])
+                .drop_duplicates("openTime", keep="last")
+                .sort_values("openTime")
+                .reset_index(drop=True)
+            )
+        k.to_csv(path, index=False)
+        print(f"  {sym}: cached {len(k)} bars -> {os.path.relpath(path)}")
+
+
+def load_panel(symbols, interval="1h", refresh=True):
+    """Return {sym: DataFrame} with ohlcv + funding/oi/basis/taker + derived
+    columns (ret, fwd_ret). Refreshes the cache first unless refresh=False."""
+    if refresh:
+        update_cache(symbols, interval)
+    panel = {}
+    for sym in symbols:
+        path = _cache_path(sym, interval)
+        if not os.path.exists(path):
+            continue
+        df = pd.read_csv(path).sort_values("openTime").reset_index(drop=True)
+        lp = np.log(df["close"].to_numpy())
+        df["ret"] = np.concatenate([[0.0], np.diff(lp)])
+        df["fwd_ret"] = np.concatenate([np.diff(lp), [np.nan]])  # t -> t+1 (the label)
+        panel[sym] = df
+    return panel
+
+
+if __name__ == "__main__":
+    import sys
+
+    syms = sys.argv[1:] or ["BTCUSDT", "ETHUSDT", "SOLUSDT", "BNBUSDT", "XRPUSDT"]
+    print(f"Updating cache for {syms} (1h)…")
+    update_cache(syms, "1h")

--- a/scripts/research/harness.py
+++ b/scripts/research/harness.py
@@ -1,0 +1,216 @@
+"""Honest large-sample evaluation harness for trading signals.
+
+Design principle: an edge must survive (1) out-of-sample walk-forward, (2)
+realistic costs, (3) a bootstrap confidence interval that respects sample size,
+and (4) a multiple-testing haircut. The point of this module is to make it hard
+to fool yourself — short, lucky windows produce wide CIs and get flagged, not
+celebrated.
+
+A "signal" is a function ``fit_predict(train_df, test_row) -> float`` predicting
+the next-bar return (sign/magnitude). Helpers below provide OLS-linear and
+momentum signals; plug in your own.
+
+Dependencies: numpy, pandas (stdlib otherwise).
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+
+PERIODS = {"1h": 24 * 365, "4h": 6 * 365, "1d": 365}
+
+
+# --------------------------------------------------------------------------- #
+# Signals: (feature_cols) -> a fit_predict closure over an expanding window     #
+# --------------------------------------------------------------------------- #
+def ols_signal(feature_cols):
+    """Expanding-window OLS of fwd_ret on standardized features. Returns a
+    z-scored prediction (pred / in-sample fitted std) so the deadband is
+    comparable across symbols."""
+
+    def fit_predict(train: pd.DataFrame, x_row: pd.Series):
+        X = train[feature_cols].to_numpy(float)
+        y = train["fwd_ret"].to_numpy(float)
+        ok = np.all(np.isfinite(np.column_stack([X, y])), axis=1)
+        X, y = X[ok], y[ok]
+        if len(y) < max(50, 5 * len(feature_cols)):
+            return 0.0
+        mu, sd = X.mean(0), X.std(0)
+        sd[sd == 0] = 1
+        Z = (X - mu) / sd
+        A = np.hstack([np.ones((len(Z), 1)), Z])
+        beta, *_ = np.linalg.lstsq(A, y, rcond=None)
+        xz = (x_row[feature_cols].to_numpy(float) - mu) / sd
+        if not np.all(np.isfinite(xz)):
+            return 0.0
+        pred = beta[0] + xz @ beta[1:]
+        fitted_sd = np.std(A @ beta) or 1e-9
+        return float(pred / fitted_sd)
+
+    return fit_predict
+
+
+def momentum_signal(col="mom_score"):
+    """Z-score the precomputed momentum column against the train distribution so
+    its scale is comparable to the OLS signal's (and the deadband applies)."""
+
+    def fit_predict(train, x_row):
+        m = train[col].to_numpy(float)
+        m = m[np.isfinite(m)]
+        if len(m) < 50:
+            return 0.0
+        mu, sd = m.mean(), (m.std() or 1e-9)
+        x = x_row.get(col, np.nan)
+        if not np.isfinite(x):
+            return 0.0
+        return float((x - mu) / sd)
+
+    return fit_predict
+
+
+# --------------------------------------------------------------------------- #
+# Walk-forward, cost-aware                                                       #
+# --------------------------------------------------------------------------- #
+def walk_forward(df, fit_predict, min_train=2000, cost=0.0005, deadband=0.3):
+    """Expanding-window OOS backtest. Position = sign(score) when |score| beats
+    the deadband, else flat. Net return charges ``cost`` per unit position
+    change. Returns a DataFrame of OOS rows with score/position/net_ret."""
+    df = df.reset_index(drop=True)
+    n = len(df)
+    rows = []
+    pos_prev = 0.0
+    for t in range(min_train, n):
+        if not np.isfinite(df.at[t, "fwd_ret"]):
+            continue
+        score = fit_predict(df.iloc[:t], df.iloc[t])
+        pos = np.sign(score) if abs(score) > deadband else 0.0
+        net = pos * df.at[t, "fwd_ret"] - cost * abs(pos - pos_prev)
+        rows.append((df.at[t, "openTime"], score, pos, df.at[t, "fwd_ret"], net))
+        pos_prev = pos
+    return pd.DataFrame(rows, columns=["openTime", "score", "pos", "fwd_ret", "net"])
+
+
+# --------------------------------------------------------------------------- #
+# Metrics with honesty built in                                                 #
+# --------------------------------------------------------------------------- #
+def sharpe(net, ppy):
+    net = np.asarray(net, float)
+    return float(np.sqrt(ppy) * net.mean() / (net.std() + 1e-12)) if len(net) else 0.0
+
+
+def block_bootstrap_sharpe_ci(net, ppy, block=24, n_boot=2000, alpha=0.05, seed=0):
+    """Moving-block bootstrap CI for the annualized sharpe (respects
+    autocorrelation). Wide CI on short samples is the point."""
+    net = np.asarray(net, float)
+    m = len(net)
+    if m < block * 2:
+        return (float("nan"), float("nan"))
+    rng = np.random.default_rng(seed)
+    nblocks = int(np.ceil(m / block))
+    starts_pool = np.arange(0, m - block + 1)
+    out = np.empty(n_boot)
+    for b in range(n_boot):
+        starts = rng.choice(starts_pool, size=nblocks)
+        sample = np.concatenate([net[s : s + block] for s in starts])[:m]
+        out[b] = sharpe(sample, ppy)
+    lo, hi = np.quantile(out, [alpha / 2, 1 - alpha / 2])
+    return (float(lo), float(hi))
+
+
+def deflated_sharpe_prob(sr_ann, n_obs, ppy, n_trials=1):
+    """Probability the true sharpe > 0 given an observed annualized sharpe, the
+    sample size, and the number of strategies tried (multiple-testing haircut).
+    Uses the standard SR standard-error ~ sqrt((1+SR_p^2/2)/(T-1)) and a
+    Šidák-style adjustment for n_trials. Returns a 0..1 probability."""
+    T = max(2, n_obs)
+    sr_p = sr_ann / np.sqrt(ppy)  # per-period sharpe
+    se = np.sqrt((1 + 0.5 * sr_p**2) / (T - 1))
+    z = sr_p / (se + 1e-12)
+    # one-sided normal CDF
+    from math import erf, sqrt
+
+    p_single = 0.5 * (1 + erf(z / sqrt(2)))
+    # haircut for having tried n_trials independent strategies
+    return float(p_single ** max(1, n_trials))
+
+
+def summarize(net, ppy, label, n_trials=1):
+    net = np.asarray(net, float)
+    n = len(net)
+    sr = sharpe(net, ppy)
+    lo, hi = block_bootstrap_sharpe_ci(net, ppy)
+    dsr = deflated_sharpe_prob(sr, n, ppy, n_trials)
+    tot = float(np.prod(1 + net) - 1)
+    pos = net[net != 0]
+    hit = float((pos > 0).mean()) if len(pos) else 0.0
+    flags = []
+    if n < 1500:
+        flags.append(f"SMALL SAMPLE (n={n}; sharpe CI is unreliable below ~1500)")
+    if not np.isnan(lo) and lo < 0 < hi:
+        flags.append("sharpe CI straddles 0 (edge not distinguishable from noise)")
+    if dsr < 0.95:
+        flags.append(f"deflated P(SR>0)={dsr:.2f} (<0.95 after {n_trials} trials)")
+    print(
+        f"  {label:18} n={n:5d}  net={100 * tot:+7.2f}%  sharpe={sr:+6.2f} "
+        f"[{lo:+.2f},{hi:+.2f}]  hit={100 * hit:4.1f}%  P(SR>0)={dsr:.2f}"
+    )
+    for f in flags:
+        print(f"        ⚠ {f}")
+    return dict(n=n, net=tot, sharpe=sr, ci=(lo, hi), hit=hit, dsr=dsr, flags=flags)
+
+
+def regime_report(oos: pd.DataFrame, df: pd.DataFrame, ppy):
+    """Split OOS net returns by the contemporaneous market regime (trend
+    up/down by 24-bar return sign) and report sharpe in each — a real edge holds
+    across regimes rather than just shorting a downtrend."""
+    j = df.set_index("openTime")
+    up, down = [], []
+    for _, r in oos.iterrows():
+        ot = r["openTime"]
+        if ot not in j.index:
+            continue
+        i = j.index.get_loc(ot)
+        if i < 24:
+            continue
+        trend = j["close"].iloc[i] / j["close"].iloc[i - 24] - 1
+        (up if trend >= 0 else down).append(r["net"])
+    print(f"  by regime: up-trend sharpe={sharpe(up, ppy):+.2f} (n={len(up)})  "
+          f"down-trend sharpe={sharpe(down, ppy):+.2f} (n={len(down)})")
+
+
+def cross_sectional(panel, score_col, cost=0.0005, top=2):
+    """Market-neutral cross-section: each bar, long the top-`top` symbols by
+    score and short the bottom-`top`, equal weight. Returns net per-bar series.
+    `score_col` must already exist in each symbol frame (a precomputed signal)."""
+    # align on common openTimes
+    common = None
+    for df in panel.values():
+        s = set(df["openTime"])
+        common = s if common is None else (common & s)
+    times = sorted(common or [])
+    rows = []
+    prev_w = {}
+    for ot in times:
+        scores, fwds = {}, {}
+        for sym, df in panel.items():
+            r = df[df["openTime"] == ot]
+            if r.empty:
+                continue
+            sc, fw = r["openTime"].index[0], None
+            scores[sym] = float(r[score_col].iloc[0]) if np.isfinite(r[score_col].iloc[0]) else None
+            fwds[sym] = float(r["fwd_ret"].iloc[0]) if np.isfinite(r["fwd_ret"].iloc[0]) else None
+        valid = [s for s in scores if scores[s] is not None and fwds[s] is not None]
+        if len(valid) < 2 * top:
+            continue
+        ranked = sorted(valid, key=lambda s: scores[s])
+        w = {s: 0.0 for s in valid}
+        for s in ranked[:top]:
+            w[s] = -1.0 / top
+        for s in ranked[-top:]:
+            w[s] = +1.0 / top
+        gross = sum(w[s] * fwds[s] for s in valid)
+        turn = sum(abs(w.get(s, 0) - prev_w.get(s, 0)) for s in set(w) | set(prev_w))
+        rows.append((ot, gross - cost * turn))
+        prev_w = w
+    return pd.DataFrame(rows, columns=["openTime", "net"])

--- a/scripts/research/run_example.py
+++ b/scripts/research/run_example.py
@@ -1,0 +1,83 @@
+"""Demo + smoke test for the research harness.
+
+Loads (and refreshes) a small symbol panel, runs a funding+basis OLS signal and a
+momentum signal through the cost-aware walk-forward, and prints rigorous reports
+with bootstrap sharpe CIs, a regime split, a multiple-testing haircut, and a
+cross-sectional book.
+
+On the currently-available ~30-day window this will (correctly) FLAG small-sample
+unreliability — that is the intended lesson: the harness refuses to bless an edge
+the data can't support. Re-run after the cache has accumulated months of history
+(via scheduled ``datafeed.update_cache``) for a verdict you can act on.
+
+Usage:  python3 scripts/research/run_example.py [SYM ...]
+"""
+
+from __future__ import annotations
+
+import sys
+
+import numpy as np
+
+import datafeed as feed
+import harness as H
+
+
+def add_features(df):
+    df = df.copy()
+    r = df["ret"].to_numpy(float)
+    n = len(r)
+    df["funding_d"] = np.concatenate([[np.nan], np.diff(df["funding"].to_numpy(float))])
+    oi = df["oi"].to_numpy(float)
+    df["doi"] = np.concatenate([[np.nan], np.diff(oi)]) / np.where(np.abs(oi) < 1e-9, np.nan, oi)
+    df["taker_imb"] = df["taker"].to_numpy(float) - 1.0
+    df["mom_score"] = np.array([np.sum(r[max(0, i - 5) : i + 1]) for i in range(n)])
+    return df
+
+
+def main():
+    syms = sys.argv[1:] or ["BTCUSDT", "ETHUSDT", "SOLUSDT", "BNBUSDT", "XRPUSDT"]
+    interval = "1h"
+    ppy = H.PERIODS[interval]
+    print(f"Loading panel {syms} @ {interval} (refreshing cache)…")
+    panel = {s: add_features(d) for s, d in feed.load_panel(syms, interval).items()}
+    if not panel:
+        print("No data — check connectivity / cache.")
+        return
+
+    # number of (signal x symbol) configurations we are scanning, for the haircut
+    n_trials = 2 * len(panel)
+    min_train = 250  # small window today; raise toward 2000+ once cache has history
+
+    print("\n=== per-symbol walk-forward (cost 5bps/turn) ===")
+    for sym, df in panel.items():
+        print(f"\n{sym}:")
+        exo = H.walk_forward(df, H.ols_signal(["funding", "basis"]), min_train=min_train)
+        H.summarize(exo["net"], ppy, "exo(funding+basis)", n_trials=n_trials)
+        H.regime_report(exo, df, ppy)
+        mom = H.walk_forward(df, H.momentum_signal(), min_train=min_train)
+        H.summarize(mom["net"], ppy, "momentum-only", n_trials=n_trials)
+
+    # cross-sectional book on the funding+basis score (precompute a simple score)
+    print("\n=== cross-sectional (long top / short bottom by -funding+basis) ===")
+    for sym, df in panel.items():
+        f = df["funding"].to_numpy(float)
+        b = df["basis"].to_numpy(float)
+        # standardize within symbol; signal = +basis - funding (per the IC signs)
+        def z(x):
+            return (x - np.nanmean(x)) / (np.nanstd(x) + 1e-12)
+        df["xs_score"] = z(b) - z(f)
+    xs = H.cross_sectional(panel, "xs_score")
+    if len(xs):
+        H.summarize(xs["net"], ppy, "cross-sectional", n_trials=n_trials)
+    else:
+        print("  (not enough overlapping bars for a cross-section yet)")
+
+    print(
+        "\nNote: small-sample flags above are expected on the ~30-day window. "
+        "Schedule datafeed.update_cache to accumulate history, then re-run."
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Why
Every signal investigated (Kalman, method-mix, optimizer warm-start, exogenous funding/basis) looked good in-sample and dissolved out-of-sample. The binding constraint is **data, not models**: Binance `/futures/data` stats return only ~30 days, so every OOS test ran on windows too short for a meaningful sharpe (bootstrap CIs straddle zero). This lands the infrastructure to evaluate signals honestly at scale and to accumulate the history the 30-day limit denies.

## What's in it (no production/trading code touched)
**`scripts/research/`** (Python; numpy/pandas/stdlib):
- `datafeed.py` — incremental **point-in-time** cache of perp OHLCV + funding/OI/basis/taker under `data/research/`. Run on a schedule to **accumulate** history past the API limit; same schema takes archival/paid data drop-in.
- `harness.py` — honest evaluator: cost-aware walk-forward, **block-bootstrap sharpe CI**, **deflated P(SR>0)** with a multiple-testing haircut, regime split, cross-sectional book. Short/lucky windows get **flagged, not blessed**.
- `run_example.py` — runnable demo; on today's ~30-day window it correctly flags small-sample unreliability (every CI straddles 0, deflated P ≤ 0.5).

**`research-notes/data-acquisition-spec.md`** — tiered acquisition plan (Tier 0 free/accumulate-now, Tier 1 paid archival — Tardis/Glassnode, Tier 2 macro/options), schema, point-in-time discipline, and the evaluation bar a signal must clear before any capital (CI excludes 0, deflated P ≥ 0.95, consistent across symbols & regimes, ≥ ~1500 OOS obs).

`data/research/` is tracked with gitignored contents (cache is generated).

## How to use
```
python3 scripts/research/datafeed.py BTCUSDT ETHUSDT SOLUSDT BNBUSDT XRPUSDT   # accumulate (cron this)
python3 scripts/research/run_example.py                                          # evaluate
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)