### PR TITLE
fix(hlint): clean up exogenous predictor hints

### DIFF
--- a/haskell/app/Trader/Predictors/Exogenous.hs
+++ b/haskell/app/Trader/Predictors/Exogenous.hs
@@ -16,6 +16,7 @@ module Trader.Predictors.Exogenous (
 
 import Data.Int (Int64)
 import Data.List (sortOn)
+import Data.Maybe (fromMaybe)
 import qualified Data.Vector as V
 
 {- | Forward-fill an irregular @(timestampMs, value)@ series onto @barOpenTimes@,
@@ -46,7 +47,7 @@ aligned series into a 'FeatureInputs' field (whose features are deltas/centered
 levels, for which 0 reads as "no information").
 -}
 neutralFill :: V.Vector (Maybe Double) -> V.Vector Double
-neutralFill = V.map (maybe 0 id)
+neutralFill = V.map (fromMaybe 0)
 
 {- | Convenience: align a raw series to bars and pack it for 'FeatureInputs'.
 Returns 'Nothing' when the series is empty (so the feature stays fully neutral),

--- a/haskell/app/Trader/Predictors/ExogenousFetch.hs
+++ b/haskell/app/Trader/Predictors/ExogenousFetch.hs
@@ -14,6 +14,7 @@ module Trader.Predictors.ExogenousFetch (
 ) where
 
 import Control.Exception (SomeException, try)
+import Data.Either (fromRight)
 import Data.Int (Int64)
 import qualified Data.Vector as V
 
@@ -44,8 +45,8 @@ fetchExogenousInputs ::
 fetchExogenousInputs env symbol period barOpenTimes intervalMs inputs = do
     let n = max 1 (V.length barOpenTimes)
         tryFetch io =
-            either (const []) id <$> (try io :: IO (Either SomeException [(Int64, Double)]))
-        align rows = alignedFeatureSeries barOpenTimes intervalMs rows
+            fromRight [] <$> (try io :: IO (Either SomeException [(Int64, Double)]))
+        align = alignedFeatureSeries barOpenTimes intervalMs
     funding <- align <$> tryFetch (fetchFundingRateHistory env symbol n)
     oi <- align <$> tryFetch (fetchOpenInterestHist env symbol period n)
     taker <- align <$> tryFetch (fetchTakerLongShortRatio env symbol period n)


### PR DESCRIPTION
`bash scripts/verify.sh haskell` failed the hlint gate on the three hints introduced by the newly-merged exogenous-features foundation (#`e513c8d5`):

- `Exogenous.hs:49` — `maybe 0 id` → `fromMaybe 0`
- `ExogenousFetch.hs:47` — `either (const []) id` → `fromRight []`
- `ExogenousFetch.hs:48` — eta-reduce `align rows = alignedFeatureSeries barOpenTimes intervalMs rows` → `align = alignedFeatureSeries barOpenTimes intervalMs`

Adds the `Data.Maybe (fromMaybe)` and `Data.Either (fromRight)` imports.

Verified locally: `hlint` reports **No hints** and `fourmolu --mode check` passes on both files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)