### PR TITLE
style: numeric underscores in AutoStartBackoff (last red hlint gate on main)

### DIFF
--- a/haskell/app/Trader/App/AutoStartBackoff.hs
+++ b/haskell/app/Trader/App/AutoStartBackoff.hs
@@ -123,8 +123,8 @@ defaultBackoffPolicy :: BackoffPolicy
 defaultBackoffPolicy =
     BackoffPolicy
         { bpInitialDelaySec = 60
-        , bpMaxDelaySec = 1800
-        , bpAuthCircuitOpenSec = 3600
+        , bpMaxDelaySec = 1_800
+        , bpAuthCircuitOpenSec = 3_600
         , bpPermanentOpenSec = 21_600 -- 6h: needs an operator change anyway
         , bpMultiplier = 2.0
         }
@@ -142,7 +142,7 @@ defaultCircuitPolicy :: CircuitPolicy
 defaultCircuitPolicy =
     CircuitPolicy
         { cpAuthThreshold = 3
-        , cpOpenDurationSec = 3600
+        , cpOpenDurationSec = 3_600
         }
 
 data CircuitState
@@ -213,13 +213,13 @@ isPermanentByCode :: Maybe Int -> Bool
 isPermanentByCode = maybe False go
   where
     go c =
-        c == (-1013)
-            || c == (-2010)
-            || c == (-2011)
-            || c == (-2022)
-            || c == (-4164)
-            || (c <= (-1100) && c >= (-1199))
-            || (c <= (-4000) && c >= (-4999))
+        c == (-1_013)
+            || c == (-2_010)
+            || c == (-2_011)
+            || c == (-2_022)
+            || c == (-4_164)
+            || (c <= (-1_100) && c >= (-1_199))
+            || (c <= (-4_000) && c >= (-4_999))
 
 isPermanentBySummary :: String -> Bool
 isPermanentBySummary summary = any (`isInfixOf` lowerSummary) phrases
@@ -250,7 +250,7 @@ initialBackoff nowMs cls msg policy =
             { sbLastErrorAtMs = nowMs
             , sbLastErrorClass = cls
             , sbConsecutiveFails = 1
-            , sbNextAllowedAtMs = nowMs + fromIntegral delaySec * 1000
+            , sbNextAllowedAtMs = nowMs + fromIntegral delaySec * 1_000
             , sbLastErrorMessage = normalizeAutoStartErrorMessage msg
             }
 
@@ -282,7 +282,7 @@ nextBackoff policy nowMs mPrev cls msg =
                     { sbLastErrorAtMs = nowMs
                     , sbLastErrorClass = cls
                     , sbConsecutiveFails = count'
-                    , sbNextAllowedAtMs = nowMs + fromIntegral base * 1000
+                    , sbNextAllowedAtMs = nowMs + fromIntegral base * 1_000
                     , sbLastErrorMessage = normalizeAutoStartErrorMessage msg
                     }
 

--- a/haskell/test/Trader/Test/AutoStartBackoff.hs
+++ b/haskell/test/Trader/Test/AutoStartBackoff.hs
@@ -114,8 +114,8 @@ testTransientMonotone = do
         chain = mkChain 6
         delays = zipWith (\a b -> sbNextAllowedAtMs b - sbLastErrorAtMs b) chain (tail chain ++ [last chain])
     -- All delays must be >= initial and <= cap, and non-decreasing until the cap.
-    let initialMs = fromIntegral (bpInitialDelaySec policy) * 1000
-        capMs = fromIntegral (bpMaxDelaySec policy) * 1000
+    let initialMs = fromIntegral (bpInitialDelaySec policy) * 1_000
+        capMs = fromIntegral (bpMaxDelaySec policy) * 1_000
     mapM_
         ( \d -> do
             expectTrue ("delay >= initial: " ++ show d) (d >= initialMs)
@@ -130,18 +130,18 @@ testTransientMonotone = do
 testAuthInitialDelay :: IO ()
 testAuthInitialDelay = do
     let sb = initialBackoff (fromInteger now) ErrAuth "401" policy
-        expected = fromInteger now + fromIntegral (bpAuthCircuitOpenSec policy) * 1000
+        expected = fromInteger now + fromIntegral (bpAuthCircuitOpenSec policy) * 1_000
     expectEq "auth initial nextAllowedAt" expected (sbNextAllowedAtMs sb)
     expectEq "auth class recorded" ErrAuth (sbLastErrorClass sb)
 
 testAuthStayHigh :: IO ()
 testAuthStayHigh = do
     let sb0 = initialBackoff (fromInteger now) ErrAuth "401" policy
-        sb1 = nextBackoff policy (fromInteger (now + 1000)) (Just sb0) ErrAuth "401"
+        sb1 = nextBackoff policy (fromInteger (now + 1_000)) (Just sb0) ErrAuth "401"
         gap1 = sbNextAllowedAtMs sb1 - sbLastErrorAtMs sb1
     expectTrue
         "second auth failure also yields >= circuit open"
-        (gap1 >= fromIntegral (bpAuthCircuitOpenSec policy) * 1000)
+        (gap1 >= fromIntegral (bpAuthCircuitOpenSec policy) * 1_000)
 
 testShouldAttemptBoundary :: IO ()
 testShouldAttemptBoundary = do
@@ -227,7 +227,7 @@ testTransientCap = do
         go k sb = go (k - 1) (nextBackoff policy (fromInteger now) (Just sb) ErrTransient "DNS")
         sbBig = go 64 (initialBackoff (fromInteger now) ErrTransient "DNS" policy)
         gapMs = sbNextAllowedAtMs sbBig - sbLastErrorAtMs sbBig
-        capMs = fromIntegral (bpMaxDelaySec policy) * 1000
+        capMs = fromIntegral (bpMaxDelaySec policy) * 1_000
     expectTrue ("gap clamped at cap: gap=" ++ show gapMs ++ " cap=" ++ show capMs) (gapMs == capMs)
 
 _unused :: Integer -> Integer
@@ -326,7 +326,7 @@ testBackoffStableAcrossIps = do
     let raw1 = "futures/positionRisk HTTP 401: Binance code -2015: Invalid API-key, IP, or permissions for action, request ip: 157.100.191.150"
         raw2 = "futures/positionRisk HTTP 401: Binance code -2015: Invalid API-key, IP, or permissions for action, request ip: 148.227.107.253"
         sb1 = initialBackoff (fromInteger now) ErrAuth raw1 policy
-        sb2 = nextBackoff policy (fromInteger (now + 1000)) (Just sb1) ErrAuth raw2
+        sb2 = nextBackoff policy (fromInteger (now + 1_000)) (Just sb1) ErrAuth raw2
     expectEq
         "backoff fingerprint stable across IP rotation"
         (sbLastErrorMessage sb1)


### PR DESCRIPTION
Follow-up to #145 (merged before this commit landed on the branch): CI's hlint still emits 21 "Use underscore" suggestions for 4-digit literals in `Trader.App.AutoStartBackoff` + its tests, keeping main red and the Fly/Hetzner deploy chain blocked. Both files already enable `NumericUnderscores`; this is the mechanical `1000` → `1_000` style change, no semantics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)