### PR TITLE
deploy(hetzner): SSH keepalives so long remote builds survive

### DIFF
--- a/deploy/hetzner/deploy-remote.sh
+++ b/deploy/hetzner/deploy-remote.sh
@@ -54,7 +54,10 @@ env_file="${TRADER_HETZNER_ENV_FILE:-deploy/hetzner/trader.env}"
 managed_env_file="${TRADER_HETZNER_MANAGED_ENV_FILE:-}"
 compose_file="${TRADER_HETZNER_COMPOSE_FILE:-deploy/hetzner/docker-compose.yml}"
 
-ssh_opts=(-p "$ssh_port" -o BatchMode=yes)
+# Keepalives: the remote `docker compose ... --build` step compiles the full
+# Haskell tree and can sit minutes without output; without these the session
+# dies with "Broken pipe" (observed on the research box, 2026-06-11).
+ssh_opts=(-p "$ssh_port" -o BatchMode=yes -o ServerAliveInterval=30 -o ServerAliveCountMax=20)
 if [[ -n "${TRADER_HETZNER_SSH_KEY_FILE:-}" ]]; then
   ssh_opts+=(-i "$TRADER_HETZNER_SSH_KEY_FILE" -o IdentitiesOnly=yes)
 fi


### PR DESCRIPTION
The Hetzner research deploy in run 27347305494 failed with `client_loop: send disconnect: Broken pipe` (SSH exit 255) — the remote `docker compose up --build` compiles the Haskell tree for minutes with no output and the session got dropped. The trading box deployed fine (faster build, warm cache).

Adds `ServerAliveInterval=30` / `ServerAliveCountMax=20` to the ssh options in `deploy-remote.sh`. One-line robustness fix, no behavior change otherwise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)