### PR TITLE
fix(main): restore learning-loop wiring dropped by the automated merge resolution

### DIFF
--- a/haskell/app/Main.hs
+++ b/haskell/app/Main.hs
@@ -205,8 +205,10 @@ import Trader.Binance (
  )
 import Trader.BinanceIntervals (binanceIntervals)
 import Trader.BotStartSemantics (
+    BacktestVerdict (..),
+    backtestVerdictAborts,
     botStartSymbolDisabled,
-    botStartupBacktestAborts,
+    botStartupBacktestVerdict,
     botTradeEnabledFromApi,
     prioritizeBotStartSymbols,
     queuedStartOrderErrorIssue,
@@ -228,6 +230,7 @@ import Trader.Coinbase (
     fetchCoinbaseAvailableBalance,
     fetchCoinbaseBaseMinSize,
     fetchCoinbaseCandles,
+    fetchCoinbaseCandlesEndingAt,
     fetchCoinbaseOrderById,
     newCoinbaseEnv,
     placeCoinbaseMarketOrder,
@@ -235,6 +238,12 @@ import Trader.Coinbase (
 import Trader.ComboTracking (activeComboUuid, orderComboUuid)
 import Trader.Config (shouldRequireUserTradeKeys, validateRuntimeConfig)
 import Trader.Cors (CorsConfig (..), corsHeadersFor, resolveCorsConfig, withCors)
+import Trader.CostCalibration (
+    calibratedSlippagePerSide,
+    costCalibrationMinObservations,
+    costCalibrationWindow,
+    observedSlippageFraction,
+ )
 import Trader.Dex (
     DexEnv (..),
     DexSwapResult (..),
@@ -264,12 +273,18 @@ import Trader.LSTM (
     LSTMConfig (..),
     LSTMModel (..),
     fineTuneLSTM,
+    fineTuneLSTMWeighted,
     paramCount,
     predictNext,
     predictNextMulti,
     predictSeriesNext,
     trainLSTM,
     trainLSTMMulti,
+ )
+import Trader.LiveGap (
+    LiveGapStats (..),
+    liveGapMethodMultiplier,
+    liveGapStatsByMethod,
  )
 import Trader.LstmPersistence (lstmModelKey)
 import Trader.MarketContext (MarketModel (..), buildMarketModel, marketMeasurementAt)
@@ -379,14 +394,21 @@ import Trader.Text (dedupeStable, normalizeKey, trim)
 import Trader.TopCombosStore (
     ComboBacktestApplyStats (..),
     ComboBacktestUpdate (..),
+    ComboLiveStats (..),
     TopCombosMergeStats (..),
     TopCombosStore (..),
     applyComboUpdatesWithStats,
+    blendedAnnualizedReturn,
     comboIdentityKey,
+    comboLiveStats,
+    comboLiveStatsFromObject,
+    comboLiveStatsValue,
     comboMetricDouble,
+    comboMetricInt,
     comboPerformanceKey,
     compactTopCombosPayloadForSync,
     isTopCombosPayload,
+    liveStatsQuarantined,
     mergeTopCombosPayloads,
     mergeTopCombosPayloadsWithStats,
     newTopCombosStore,
@@ -396,6 +418,7 @@ import Trader.TopCombosStore (
     resolveComboSymbol,
     sanitizeComboSymbolForPlatform,
     sanitizeTopCombosValue,
+    setComboLiveStats,
     topCombosGeneratedAtMs,
     topCombosPayloadEquivalent,
     withTopCombosLock,
@@ -418,6 +441,7 @@ import Trader.Trading (
     simulateEnsemble,
     simulateEnsembleWithHLChecked,
     tradeEntrySourceCode,
+    tradeOutcomeWeights,
  )
 import Trader.VolConfGate (
     VolConfGateBehavior (..),
@@ -3926,6 +3950,7 @@ updateComboPerformanceFromCompletedOperation conn now comboUuid currentEq = do
                         _ -> KM.empty
                 (nextFinalEq, nextAnnualized, metricsObj') =
                     recalculateComboPerformanceFromOperation
+                        now
                         (T.unpack <$> mInterval)
                         mFinalEq
                         mAnnualized
@@ -5171,6 +5196,7 @@ data BotState = BotState
     , botPositions :: !(V.Vector Int) -- position after decision at each bar (len == prices)
     , botOps :: ![BotOp]
     , botOrders :: ![BotOrderEvent]
+    , botRestoredSlippages :: ![Double] -- fill-slippage observations restored from the previous session's snapshot
     , botTrades :: ![Trade]
     , botPerfStats :: !BotPerfStats
     , botAdjustments :: !BotAdjustments
@@ -6008,6 +6034,15 @@ botStatusJson st =
             , "openTrade" .= fmap botOpenTradeJson (botOpenTrade st)
             , "performance" .= perfJson
             , "adaptive" .= adaptiveJson
+            , "costCalibration"
+                .= let obs = botSlippageObservations st
+                       configured = argSlippage (botArgs st)
+                    in object
+                        [ "configuredSlippage" .= configured
+                        , "calibratedSlippage" .= calibratedSlippagePerSide configured obs
+                        , "observations" .= length obs
+                        , "minObservations" .= costCalibrationMinObservations
+                        ]
             , "latestSignal" .= botLatestSignal st
             , "decisionTrace" .= botDecisionTrace st
             , "buildCommit" .= botBuildCommit st
@@ -6522,6 +6557,85 @@ lossStreakFromTrades trades =
             (\tr -> let r = trReturn tr in isNaN r || isInfinite r || r <= 0)
             (reverse trades)
         )
+
+{- | Realized fill-slippage observations (oldest-first) from this session's
+order events. Only orders that were actually sent and filled measure
+anything; dry-run and rejected orders are skipped.
+-}
+realizedSlippagesFromOrderEvents :: [BotOrderEvent] -> [Double]
+realizedSlippagesFromOrderEvents events =
+    [ slip
+    | e <- events
+    , let o = boeOrder e
+    , aorSent o
+    , Just slip <-
+        [ observedSlippageFraction
+            (boeOpSide e)
+            (boePrice e)
+            (aorExecutedQty o)
+            (aorCummulativeQuoteQty o)
+        ]
+    ]
+
+{- | Extract one fill-slippage observation from a persisted order-event JSON
+object (the snapshot's @orders@ array). Field names follow the
+'BotOrderEvent' / 'ApiOrderResult' ToJSON encodings.
+-}
+slippageFromOrderEventValue :: Aeson.Value -> Maybe Double
+slippageFromOrderEventValue val = do
+    o <- case val of
+        Aeson.Object obj -> Just obj
+        _ -> Nothing
+    side <- KM.lookup "opSide" o >>= AT.parseMaybe Aeson.parseJSON
+    price <- KM.lookup "price" o >>= AT.parseMaybe Aeson.parseJSON
+    orderObj <- case KM.lookup "order" o of
+        Just (Aeson.Object oo) -> Just oo
+        _ -> Nothing
+    sent <- KM.lookup "sent" orderObj >>= AT.parseMaybe Aeson.parseJSON
+    if not sent
+        then Nothing
+        else
+            observedSlippageFraction
+                side
+                price
+                (KM.lookup "executedQty" orderObj >>= AT.parseMaybe Aeson.parseJSON)
+                (KM.lookup "cummulativeQuoteQty" orderObj >>= AT.parseMaybe Aeson.parseJSON)
+
+{- | Seed cost calibration from the previous session's snapshot, mirroring
+'restoreTradeMemoryFromSnapshotMaybe': bots restart on every deploy, and
+without a seed the calibration would fall back to the configured slippage
+for the first 'costCalibrationMinObservations' fills of each session.
+Fail-open: no snapshot, a context mismatch, or unparseable orders mean no
+seed.
+-}
+restoreSlippageObservationsFromSnapshotMaybe :: Maybe FilePath -> TenantKey -> Args -> String -> IO [Double]
+restoreSlippageObservationsFromSnapshotMaybe mDir tenantKey args sym = do
+    mSnap <- readBotStatusSnapshotMaybe mDir tenantKey sym
+    let restored =
+            case mSnap of
+                Nothing -> []
+                Just snap ->
+                    if not (botSnapshotMatchesTradeMemoryContext args sym (bssStatus snap))
+                        then []
+                        else case bssStatus snap of
+                            Aeson.Object o ->
+                                case KM.lookup "orders" o of
+                                    Just (Aeson.Array ordersV) ->
+                                        takeLast
+                                            costCalibrationWindow
+                                            (mapMaybe slippageFromOrderEventValue (V.toList ordersV))
+                                    _ -> []
+                            _ -> []
+    pure restored
+
+{- | All fill-slippage observations available to a bot, oldest-first:
+last session's restored tail, then this session's order events.
+-}
+botSlippageObservations :: BotState -> [Double]
+botSlippageObservations st =
+    takeLast
+        costCalibrationWindow
+        (botRestoredSlippages st ++ realizedSlippagesFromOrderEvents (botOrders st))
 
 data BotOp = BotOp
     { boIndex :: !Int
@@ -7062,7 +7176,10 @@ applyAdoptRequirementArgs args req
 
 selectCompatibleTopComboArgs :: ApiComputeLimits -> String -> Args -> AdoptRequirement -> TopCombosExport -> Maybe (Args, Maybe Text)
 selectCompatibleTopComboArgs limits sym args req export =
-    let combos = filter (topComboMatchesSymbol sym Nothing) (tceCombos export)
+    let combos =
+            filter
+                (\c -> topComboMatchesSymbol sym Nothing c && not (topComboLiveQuarantined c))
+                (tceCombos export)
         sortedCombos = sortOn topComboTradePriorityKey combos
         pick [] = Nothing
         pick (combo : rest) =
@@ -7286,39 +7403,58 @@ runTopComboStartupBacktestGuard ctx tenantKey sym args (Just comboUuid) = do
                                             pure (Right ())
                                         Just metricsVal -> do
                                             let mFinalEq = comboMetricDouble "finalEquity" metricsVal
+                                                mTradeCount = comboMetricInt "tradeCount" metricsVal
                                                 objective =
                                                     case Aeson.fromJSON comboVal :: Aeson.Result TopCombo of
                                                         Aeson.Success combo -> fromMaybe "final-equity" (tcObjectiveLabel combo)
                                                         Aeson.Error _ -> "final-equity"
-                                                update =
-                                                    ComboBacktestUpdate
-                                                        { cbuMetrics = metricsVal
-                                                        , cbuFinalEquity = mFinalEq
-                                                        , cbuScore = objectiveScoreFromMetrics argsOk objective metricsVal
-                                                        , cbuOperations = extractBacktestOperations out
-                                                        }
-                                            updateResult <- applyStartupComboBacktestUpdate ctx comboKey update
-                                            -- Reached only when the guard is enabled (disabled boxes
-                                            -- short-circuit above). A start aborts only on a genuine
-                                            -- sub-threshold ROI reading; a missing finalEquity fails open.
-                                            let acceptable = not (botStartupBacktestAborts (tcbcEnabled ctx) mFinalEq)
-                                            case updateResult of
-                                                Left err -> do
-                                                    let msg = "Top-combo startup backtest failed: " ++ err
-                                                    recordTopComboStartupBacktestEvent ctx tenantKey "bot.start_combo_backtest_failed" sym comboUuid mFinalEq (Just msg)
-                                                    if acceptable
-                                                        then pure (Right ())
-                                                        else pure (Left msg)
-                                                Right stats -> do
-                                                    recordTopComboStartupBacktestEvent ctx tenantKey "bot.start_combo_backtest" sym comboUuid mFinalEq Nothing
-                                                    let pruned = cbasPrunedCount stats > 0
-                                                    when pruned (deleteTopComboFromDbMaybe (tcbcOps ctx) comboUuid)
-                                                    if acceptable
-                                                        then pure (Right ())
-                                                        else do
-                                                            let msg = topComboStartupAbortMessage sym comboUuid mFinalEq pruned
-                                                            recordTopComboStartupBacktestEvent ctx tenantKey "bot.start_combo_backtest_aborted" sym comboUuid mFinalEq (Just msg)
-                                                            pure (Left msg)
+                                                verdict = botStartupBacktestVerdict (tcbcEnabled ctx) mFinalEq mTradeCount
+                                            case verdict of
+                                                BacktestNoVerdict -> do
+                                                    -- Zero-trade (or unknown-trade) smoke window. Do NOT
+                                                    -- persist the smoke metrics onto the combo and do NOT
+                                                    -- prune it: the on-disk metrics are the optimizer's
+                                                    -- out-of-sample reading, which is the right artifact
+                                                    -- to keep. Pruning here would silently delete healthy
+                                                    -- combos every quiet day (124 such erroneous prunes
+                                                    -- in the 2026-06-10 launchd log).
+                                                    let reason =
+                                                            "top-combo startup backtest produced no verdict (tradeCount="
+                                                                ++ maybe "unknown" show mTradeCount
+                                                                ++ ", finalEquity="
+                                                                ++ maybe "unknown" (printf "%.6f") mFinalEq
+                                                                ++ "); allowing start without persisting smoke metrics."
+                                                    recordTopComboStartupBacktestEvent ctx tenantKey "bot.start_combo_backtest_no_verdict" sym comboUuid mFinalEq (Just reason)
+                                                    pure (Right ())
+                                                _ -> do
+                                                    let update =
+                                                            ComboBacktestUpdate
+                                                                { cbuMetrics = metricsVal
+                                                                , cbuFinalEquity = mFinalEq
+                                                                , cbuScore = objectiveScoreFromMetrics argsOk objective metricsVal
+                                                                , cbuOperations = extractBacktestOperations out
+                                                                }
+                                                    updateResult <- applyStartupComboBacktestUpdate ctx comboKey update
+                                                    -- Reached only when the verdict is Allow or Abort and the
+                                                    -- guard is enabled (disabled boxes return Allow above).
+                                                    let acceptable = not (backtestVerdictAborts verdict)
+                                                    case updateResult of
+                                                        Left err -> do
+                                                            let msg = "Top-combo startup backtest failed: " ++ err
+                                                            recordTopComboStartupBacktestEvent ctx tenantKey "bot.start_combo_backtest_failed" sym comboUuid mFinalEq (Just msg)
+                                                            if acceptable
+                                                                then pure (Right ())
+                                                                else pure (Left msg)
+                                                        Right stats -> do
+                                                            recordTopComboStartupBacktestEvent ctx tenantKey "bot.start_combo_backtest" sym comboUuid mFinalEq Nothing
+                                                            let pruned = cbasPrunedCount stats > 0
+                                                            when pruned (deleteTopComboFromDbMaybe (tcbcOps ctx) comboUuid)
+                                                            if acceptable
+                                                                then pure (Right ())
+                                                                else do
+                                                                    let msg = topComboStartupAbortMessage sym comboUuid mFinalEq pruned
+                                                                    recordTopComboStartupBacktestEvent ctx tenantKey "bot.start_combo_backtest_aborted" sym comboUuid mFinalEq (Just msg)
+                                                                    pure (Left msg)
 
 clearPositionOriginIfFlatMaybe :: Maybe OpsStore -> TenantKey -> Args -> String -> IO ()
 clearPositionOriginIfFlatMaybe mOps tenantKey args sym =
@@ -7423,6 +7559,7 @@ topCombosTopTargets disabledSymbols topN export =
         targets =
             [ (normalizeSymbol sym, combo)
             | combo <- sorted
+            , not (topComboLiveQuarantined combo)
             , Just sym <- [topComboSymbol combo]
             , not (null sym)
             , not (botStartSymbolDisabled disabledSymbols sym)
@@ -8417,6 +8554,14 @@ initBotState mBotStateDir mOps tenantKey args settings mComboUuid originIp sym =
                     else pure pos
             else pure 0
     restoredTrades <- restoreTradeMemoryFromSnapshotMaybe mBotStateDir tenantKey args sym
+    restoredSlippages <- restoreSlippageObservationsFromSnapshotMaybe mBotStateDir tenantKey args sym
+    unless (null restoredSlippages) $
+        putStrLn
+            ( printf
+                "Restored %d fill-slippage observations of cost-calibration memory for %s."
+                (length restoredSlippages)
+                sym
+            )
     unless (null restoredTrades) $
         putStrLn
             ( printf
@@ -8907,6 +9052,7 @@ initBotState mBotStateDir mOps tenantKey args settings mComboUuid originIp sym =
                 , botPositions = pos2
                 , botOps = ops2
                 , botOrders = orders2
+                , botRestoredSlippages = restoredSlippages
                 , botTrades = restoredTrades
                 , botPerfStats = restoredPerfStats
                 , botAdjustments = restoredAdjustments
@@ -9790,6 +9936,23 @@ botOptimizerLoop mOps _metrics mJournal topCombosStore stVar stopSig pending = d
 
     loop
 
+{- | Base discovery sampling weights for the auto-optimizer, keyed by the
+flag passed to optimize-equity and the @params.method@ code combos carry.
+Each cycle these are scaled by 'liveGapMethodMultiplier', so method
+families whose combos chronically underdeliver live lose discovery budget
+and families that hold up live gain it.
+-}
+autoOptimizerBaseMethodWeights :: [(String, String, Double)]
+autoOptimizerBaseMethodWeights =
+    [ ("--method-weight-11", "11", 0.0)
+    , ("--method-weight-10", "10", 4.0)
+    , ("--method-weight-01", "01", 0.1)
+    , ("--method-weight-edge-blend", "edge_blend", 0.0)
+    , ("--method-weight-edge-pick", "edge_pick", 0.0)
+    , ("--method-weight-regime-switch", "regime_switch", 0.0)
+    , ("--method-weight-bandit-router", "bandit_router", 0.0)
+    ]
+
 autoOptimizerLoop :: Args -> Maybe StateSyncTarget -> Maybe OpsStore -> Maybe Journal -> FilePath -> TopCombosStore -> IO ()
 autoOptimizerLoop baseArgs mStateSyncTarget mOps mJournal optimizerTmp topCombosStore = do
     enabledEnv <- lookupEnv "TRADER_OPTIMIZER_ENABLED"
@@ -9950,9 +10113,7 @@ autoOptimizerLoop baseArgs mStateSyncTarget mOps mJournal optimizerTmp topCombos
                                         -- Coinbase data (fail-open if the symbol/interval is not eligible).
                                         crossExchangeArgs :: [String]
                                         crossExchangeArgs =
-                                            if readEnvBool crossExchangeEnv False
-                                                then ["--cross-exchange-coinbase"]
-                                                else []
+                                            ["--cross-exchange-coinbase" | readEnvBool crossExchangeEnv False]
                                         discoveryRecoveryEnabled = readEnvBool discoveryRecoveryEnabledEnv True
                                         discoveryRecoveryTrials :: Int
                                         discoveryRecoveryTrials =
@@ -10023,6 +10184,53 @@ autoOptimizerLoop baseArgs mStateSyncTarget mOps mJournal optimizerTmp topCombos
                                             let sleepSec s = threadDelay (max 1 s * 1000000)
 
                                                 loop = do
+                                                    -- Live-vs-backtest gap feedback: read the current combos (with
+                                                    -- whatever live records the fleet has propagated), aggregate the
+                                                    -- gap per method family, and reweight this cycle's discovery
+                                                    -- sampling accordingly. Fail-open to the base weights.
+                                                    liveGapStatsMap <- do
+                                                        valOrErr <-
+                                                            try (readTopCombosValueWithDbFallback mOps topCombosStore) ::
+                                                                IO (Either SomeException (Either String Aeson.Value))
+                                                        case valOrErr of
+                                                            Right (Right v) -> do
+                                                                v' <- annotateTopCombosValueWithLiveStats mOps v
+                                                                pure $ case v' of
+                                                                    Aeson.Object o
+                                                                        | Just (Aeson.Array combosArr) <- KM.lookup "combos" o ->
+                                                                            liveGapStatsByMethod (V.toList combosArr)
+                                                                    _ -> M.empty
+                                                            _ -> pure M.empty
+                                                    let liveGapWeightArgs =
+                                                            concat
+                                                                [ [flag, printf "%.4f" (base * liveGapMethodMultiplier (M.lookup key liveGapStatsMap)) :: String]
+                                                                | (flag, key, base) <- autoOptimizerBaseMethodWeights
+                                                                ]
+                                                        liveGapActive =
+                                                            or
+                                                                [ base > 0 && liveGapMethodMultiplier (M.lookup key liveGapStatsMap) /= 1
+                                                                | (_, key, base) <- autoOptimizerBaseMethodWeights
+                                                                ]
+                                                    when liveGapActive $ do
+                                                        nowGap <- getTimestampMs
+                                                        journalWriteMaybe
+                                                            mJournal
+                                                            ( object
+                                                                [ "type" .= ("optimizer.auto.live_gap" :: String)
+                                                                , "atMs" .= nowGap
+                                                                , "methods"
+                                                                    .= object
+                                                                        [ AK.fromString m
+                                                                            .= object
+                                                                                [ "combos" .= lgsCombos s
+                                                                                , "operations" .= lgsOperations s
+                                                                                , "opsWeightedGap" .= lgsOpsWeightedGap s
+                                                                                , "multiplier" .= liveGapMethodMultiplier (Just s)
+                                                                                ]
+                                                                        | (m, s) <- M.toList liveGapStatsMap
+                                                                        ]
+                                                                ]
+                                                            )
                                                     mSym <- pickRandom symbols
                                                     mInterval <- pickRandom intervals
                                                     case (mSym, mInterval) of
@@ -10152,21 +10360,8 @@ autoOptimizerLoop baseArgs mStateSyncTarget mOps mJournal optimizerTmp topCombos
                                                                                     , "0.0"
                                                                                     , "--p-confirm-quantiles"
                                                                                     , "0.0"
-                                                                                    , "--method-weight-11"
-                                                                                    , "0.0"
-                                                                                    , "--method-weight-10"
-                                                                                    , "0.0"
-                                                                                    , "--method-weight-01"
-                                                                                    , "4.0"
-                                                                                    , "--method-weight-edge-blend"
-                                                                                    , "0.0"
-                                                                                    , "--method-weight-edge-pick"
-                                                                                    , "0.0"
-                                                                                    , "--method-weight-regime-switch"
-                                                                                    , "0.0"
-                                                                                    , "--method-weight-bandit-router"
-                                                                                    , "0.0"
                                                                                     ]
+                                                                                        ++ liveGapWeightArgs
                                                                                 primaryMethodArgs =
                                                                                     [ "--epochs-max"
                                                                                     , show epochsMax
@@ -10176,21 +10371,8 @@ autoOptimizerLoop baseArgs mStateSyncTarget mOps mJournal optimizerTmp topCombos
                                                                                     , "0.0"
                                                                                     , "--p-confirm-quantiles"
                                                                                     , "0.0"
-                                                                                    , "--method-weight-11"
-                                                                                    , "0.0"
-                                                                                    , "--method-weight-10"
-                                                                                    , "0.0"
-                                                                                    , "--method-weight-01"
-                                                                                    , "4.0"
-                                                                                    , "--method-weight-edge-blend"
-                                                                                    , "0.0"
-                                                                                    , "--method-weight-edge-pick"
-                                                                                    , "0.0"
-                                                                                    , "--method-weight-regime-switch"
-                                                                                    , "0.0"
-                                                                                    , "--method-weight-bandit-router"
-                                                                                    , "0.0"
                                                                                     ]
+                                                                                        ++ liveGapWeightArgs
                                                                                 cliArgs = mkCliArgs recordsPath seed trials timeoutSec minRoundTrips minExposure minSharpe minCalmar primaryMethodArgs
                                                                                 recoveryCliArgs =
                                                                                     mkCliArgs
@@ -10481,7 +10663,11 @@ backtestTopCombosOnce topNRaw ctx = do
                                                                     recordEvent "optimizer.combos.backtest_skipped" ["reason" .= ("no matching combos" :: String)]
                                                                     pure False
                                                                 else do
-                                                                    writeResult <- writeTopCombosValue topJsonPath updatedVal
+                                                                    -- Embed this instance's live records before writing, so the
+                                                                    -- file/S3 payload carries them to the rest of the fleet and
+                                                                    -- to the research box's live-gap analysis.
+                                                                    updatedValLive <- annotateTopCombosValueWithLiveStats (tcbcOps ctx) updatedVal
+                                                                    writeResult <- writeTopCombosValue topJsonPath updatedValLive
                                                                     case writeResult of
                                                                         Left err -> do
                                                                             recordError "optimizer.combos.backtest_failed" err Nothing Nothing
@@ -10750,7 +10936,19 @@ botApplyKlineSafe mOps metrics mJournal mWebhook topCombosCtx ctrl st k = do
 botApplyKline :: Maybe OpsStore -> Metrics -> Maybe Journal -> Maybe Webhook -> TopCombosBacktestCtx -> BotController -> BotState -> Kline -> IO BotState
 botApplyKline mOps metrics mJournal mWebhook topCombosCtx ctrl st k = do
     now <- getTimestampMs
-    let args = botArgs st
+    -- Realized fills recalibrate the slippage assumption for this bar, so the
+    -- entry fee-buffer gates and per-order cost accounting price trades at
+    -- what execution actually costs instead of the static --slippage guess.
+    -- botArgs itself stays configured; the calibration is recomputed per bar
+    -- from the (restored + session) fill observations.
+    let argsConfigured = botArgs st
+        args =
+            argsConfigured
+                { argSlippage =
+                    calibratedSlippagePerSide
+                        (argSlippage argsConfigured)
+                        (botSlippageObservations st)
+                }
         argsSignal = applyBotAdjustments (botAdjustments st) args
         lookback = botLookback st
         settings = botSettings st
@@ -10896,6 +11094,11 @@ botApplyKline mOps metrics mJournal mWebhook topCombosCtx ctrl st k = do
                 pure (Just (predictors, kal', hmm', sv'))
 
     -- LSTM: append the new observation and fine-tune for a few epochs.
+    -- Closed-trade outcomes weight the fine-tune loss: bars a losing trade
+    -- spanned train hardest (correct the mistake), bars a winning trade
+    -- spanned train harder than uninvolved bars (reinforce the pattern).
+    -- botTrades indices share obsAll's index space (both are trimmed by the
+    -- same dropCount), so the weight slice aligns with obsTrain.
     mLstmCtx1 <-
         case botLstmCtx st of
             Nothing -> pure Nothing
@@ -10903,6 +11106,7 @@ botApplyKline mOps metrics mJournal mWebhook topCombosCtx ctrl st k = do
                 let obsAll' = obsAll ++ forwardSeries normState [priceNew]
                     trainBars = max (lookback + 2) (bsTrainBars settings)
                     obsTrain = takeLast trainBars obsAll'
+                    outcomeWeights = takeLast trainBars (tradeOutcomeWeights (botTrades st) (length obsAll'))
                     epochs = bsOnlineEpochs settings
                     cfg =
                         LSTMConfig
@@ -10918,7 +11122,7 @@ botApplyKline mOps metrics mJournal mWebhook topCombosCtx ctrl st k = do
                     (lstmModel1, _) =
                         if epochs <= 0
                             then (lstmModel0, [])
-                            else fineTuneLSTM cfg lstmModel0 obsTrain
+                            else fineTuneLSTMWeighted cfg lstmModel0 obsTrain outcomeWeights
                 mPath <- lstmWeightsPath args lookback
                 savePersistedLstmModelMaybe mPath (length obsTrain) lstmModel1
                 pure (Just (normState, obsAll', lstmModel1))
@@ -15079,7 +15283,7 @@ readTopCombosExportWithDbFallback mOps store = do
         Right val ->
             case Aeson.fromJSON val of
                 Aeson.Error err -> pure (Left ("Failed to parse top combos JSON: " ++ err))
-                Aeson.Success out -> pure (Right out)
+                Aeson.Success out -> Right <$> annotateTopCombosExportWithLiveStats mOps out
 
 persistTopCombosMaybe :: Maybe StateSyncTarget -> FilePath -> IO ()
 persistTopCombosMaybe mSync path = do
@@ -15196,6 +15400,107 @@ fetchTopComboOperationCounts conn combos =
                         IO [(UUID.UUID, Int64)]
                 pure (M.fromList [(comboUuid, fromIntegral count) | (comboUuid, count) <- rows])
 
+fetchComboLiveStatsMap :: Connection -> [UUID.UUID] -> IO (M.Map UUID.UUID ComboLiveStats)
+fetchComboLiveStatsMap conn comboUuidsRaw =
+    let comboUuids = dedupeStable comboUuidsRaw
+     in if null comboUuids
+            then pure M.empty
+            else do
+                rows <-
+                    query
+                        conn
+                        "SELECT combo_uuid, metrics_json->>'live' FROM combos WHERE combo_uuid = ANY(?) AND metrics_json IS NOT NULL AND jsonb_exists(metrics_json, 'live')"
+                        (Only (PGArray comboUuids)) ::
+                        IO [(UUID.UUID, Maybe Text)]
+                pure $
+                    M.fromList
+                        [ (comboUuid, stats)
+                        | (comboUuid, mLiveText) <- rows
+                        , Just liveVal <- [decodeJsonTextMaybe mLiveText]
+                        , Just stats <- [comboLiveStatsFromObject (KM.singleton (AK.fromString "live") liveVal)]
+                        ]
+
+annotateTopComboWithLiveStats :: M.Map UUID.UUID ComboLiveStats -> TopCombo -> TopCombo
+annotateTopComboWithLiveStats liveMap combo =
+    case uuidFromText (topComboUuid combo) >>= (`M.lookup` liveMap) of
+        Just stats
+            -- Only adopt the DB record when it is richer than whatever the
+            -- payload already carries (e.g. from another instance).
+            | maybe True ((< clsOperationCount stats) . clsOperationCount) (topComboLiveStats combo) ->
+                combo
+                    { tcMetrics =
+                        Just
+                            ( KM.insert
+                                (AK.fromString "live")
+                                (comboLiveStatsValue stats)
+                                (fromMaybe KM.empty (tcMetrics combo))
+                            )
+                    }
+        _ -> combo
+
+{- | Join realized live performance from the local @combos@ table onto a
+top-combos export so ranking and bot-start selection see it. Fail-open:
+live stats are advisory, so any DB error leaves the export unannotated.
+-}
+annotateTopCombosExportWithLiveStats :: Maybe OpsStore -> TopCombosExport -> IO TopCombosExport
+annotateTopCombosExportWithLiveStats mOps export =
+    case mOps of
+        Nothing -> pure export
+        Just store -> do
+            let comboUuids = mapMaybe (uuidFromText . topComboUuid) (tceCombos export)
+            result <-
+                try (withOpsConnection store (`fetchComboLiveStatsMap` comboUuids)) ::
+                    IO (Either SomeException (M.Map UUID.UUID ComboLiveStats))
+            case result of
+                Left _ -> pure export
+                Right liveMap
+                    | M.null liveMap -> pure export
+                    | otherwise ->
+                        pure export{tceCombos = map (annotateTopComboWithLiveStats liveMap) (tceCombos export)}
+
+comboUuidFromValue :: Aeson.Value -> Maybe UUID.UUID
+comboUuidFromValue val =
+    case val of
+        Aeson.Object o ->
+            KM.lookup "uuid" o
+                >>= AT.parseMaybe Aeson.parseJSON
+                >>= uuidFromText
+        _ -> Nothing
+
+{- | Value-level twin of 'annotateTopCombosExportWithLiveStats': join live
+stats from the local @combos@ table onto a raw top-combos payload. Used
+before the payload is written to disk so the file (and everything synced
+from it — the S3 combo bus, other instances, the research box's gap
+analysis) carries the live records this instance accumulated. Fail-open on
+any DB error.
+-}
+annotateTopCombosValueWithLiveStats :: Maybe OpsStore -> Aeson.Value -> IO Aeson.Value
+annotateTopCombosValueWithLiveStats mOps val =
+    case (mOps, val) of
+        (Just store, Aeson.Object o)
+            | Just (Aeson.Array combos) <- KM.lookup "combos" o -> do
+                let comboUuids = mapMaybe comboUuidFromValue (V.toList combos)
+                result <-
+                    try (withOpsConnection store (`fetchComboLiveStatsMap` comboUuids)) ::
+                        IO (Either SomeException (M.Map UUID.UUID ComboLiveStats))
+                case result of
+                    Left _ -> pure val
+                    Right liveMap
+                        | M.null liveMap -> pure val
+                        | otherwise ->
+                            let richer stats comboVal =
+                                    maybe
+                                        True
+                                        ((< clsOperationCount stats) . clsOperationCount)
+                                        (comboLiveStats comboVal)
+                                annotate comboVal =
+                                    case comboUuidFromValue comboVal >>= (`M.lookup` liveMap) of
+                                        Just stats
+                                            | richer stats comboVal -> setComboLiveStats stats comboVal
+                                        _ -> comboVal
+                             in pure (Aeson.Object (KM.insert "combos" (Aeson.Array (V.map annotate combos)) o))
+        _ -> pure val
+
 persistTopCombosToDb :: Connection -> TopCombosExport -> IO ()
 persistTopCombosToDb conn export =
     withTransaction conn $ do
@@ -15233,7 +15538,14 @@ persistTopCombosToDb conn export =
                                 <> "open_threshold = EXCLUDED.open_threshold, "
                                 <> "close_threshold = EXCLUDED.close_threshold, "
                                 <> "params_json = EXCLUDED.params_json, "
-                                <> "metrics_json = EXCLUDED.metrics_json, "
+                                -- A payload combo without live stats must not erase the live
+                                -- record accumulated in this DB from completed orders.
+                                <> "metrics_json = CASE "
+                                <> "WHEN combos.metrics_json IS NOT NULL "
+                                <> "AND jsonb_exists(combos.metrics_json, 'live') "
+                                <> "AND (EXCLUDED.metrics_json IS NULL OR NOT jsonb_exists(EXCLUDED.metrics_json, 'live')) "
+                                <> "THEN COALESCE(EXCLUDED.metrics_json, '{}'::jsonb) || jsonb_build_object('live', combos.metrics_json->'live') "
+                                <> "ELSE EXCLUDED.metrics_json END, "
                                 <> "operation_count = EXCLUDED.operation_count, "
                                 <> "updated_at_ms = EXCLUDED.updated_at_ms"
                             )
@@ -15464,10 +15776,22 @@ topComboMetricDouble key combo = do
 topComboTradeCount :: TopCombo -> Int
 topComboTradeCount combo = fromMaybe 0 (topComboMetricInt "tradeCount" combo)
 
+topComboLiveStats :: TopCombo -> Maybe ComboLiveStats
+topComboLiveStats combo = tcMetrics combo >>= comboLiveStatsFromObject
+
+topComboLiveQuarantined :: TopCombo -> Bool
+topComboLiveQuarantined combo = maybe False liveStatsQuarantined (topComboLiveStats combo)
+
+{- | Backtest annualized return blended with realized live performance;
+quarantined combos rank as -inf so they sink everywhere.
+-}
 topComboAnnualizedReturn :: TopCombo -> Double
 topComboAnnualizedReturn combo =
     let ann = fromMaybe (negate (1 / 0)) (topComboMetricDouble "annualizedReturn" combo)
-     in if isNaN ann || isInfinite ann then negate (1 / 0) else ann
+        ann' = if isNaN ann || isInfinite ann then negate (1 / 0) else ann
+     in if topComboLiveQuarantined combo
+            then negate (1 / 0)
+            else blendedAnnualizedReturn ann' (topComboLiveStats combo)
 
 topComboRankKey :: TopCombo -> (Double, Double, Double, Int)
 topComboRankKey combo =
@@ -15500,7 +15824,7 @@ topComboMatchesSymbol symRaw mInterval combo =
 
 bestTopComboFromList :: [TopCombo] -> Maybe TopCombo
 bestTopComboFromList combos =
-    case sortOn topComboTradePriorityKey combos of
+    case sortOn topComboTradePriorityKey (filter (not . topComboLiveQuarantined) combos) of
         [] -> Nothing
         (c : _) -> Just c
 
@@ -28828,11 +29152,14 @@ buildCrossExchangeCoinbase args pricesV mOpenTimes
     | not (argCrossExchangeCoinbase args) = pure Nothing
     | argPlatform args /= PlatformBinance = pure Nothing
     | otherwise =
-        case (argBinanceSymbol args >>= coinbaseProductFromBinance, coinbaseIntervalSeconds (argInterval args), mOpenTimes) of
+        case ((argCrossExchangeSymbol args <|> argBinanceSymbol args) >>= coinbaseProductFromBinance, coinbaseIntervalSeconds (argInterval args), mOpenTimes) of
             (Just product, Just gran, Just openTimes)
                 | n > 0 && length openTimes == n -> do
+                    -- End the Coinbase fetch at the data window's last bar (not "now")
+                    -- so historical optimizer-CSV windows align correctly too.
+                    let endSec = maximum openTimes `div` 1000
                     res <-
-                        try (fetchCoinbaseCandles product gran (n + 5)) ::
+                        try (fetchCoinbaseCandlesEndingAt product gran endSec (n + 5)) ::
                             IO (Either SomeException [CoinbaseCandle])
                     case res of
                         Left ex -> do

--- a/haskell/app/Main.hs
+++ b/haskell/app/Main.hs
@@ -15538,12 +15538,17 @@ persistTopCombosToDb conn export =
                                 <> "open_threshold = EXCLUDED.open_threshold, "
                                 <> "close_threshold = EXCLUDED.close_threshold, "
                                 <> "params_json = EXCLUDED.params_json, "
-                                -- A payload combo without live stats must not erase the live
-                                -- record accumulated in this DB from completed orders.
+                                -- A payload combo must not erase or downgrade the live record
+                                -- accumulated in this DB from completed orders: a payload
+                                -- without live stats keeps the DB record, and a stale payload
+                                -- with fewer live operations loses to the richer DB record
+                                -- (same comparison as the in-memory annotation path).
                                 <> "metrics_json = CASE "
                                 <> "WHEN combos.metrics_json IS NOT NULL "
                                 <> "AND jsonb_exists(combos.metrics_json, 'live') "
-                                <> "AND (EXCLUDED.metrics_json IS NULL OR NOT jsonb_exists(EXCLUDED.metrics_json, 'live')) "
+                                <> "AND (EXCLUDED.metrics_json IS NULL OR NOT jsonb_exists(EXCLUDED.metrics_json, 'live') "
+                                <> "OR COALESCE((EXCLUDED.metrics_json->'live'->>'operationCount')::numeric, 0) "
+                                <> "< COALESCE((combos.metrics_json->'live'->>'operationCount')::numeric, 0)) "
                                 <> "THEN COALESCE(EXCLUDED.metrics_json, '{}'::jsonb) || jsonb_build_object('live', combos.metrics_json->'live') "
                                 <> "ELSE EXCLUDED.metrics_json END, "
                                 <> "operation_count = EXCLUDED.operation_count, "

--- a/haskell/app/Trader/CostCalibration.hs
+++ b/haskell/app/Trader/CostCalibration.hs
@@ -1,0 +1,137 @@
+{- | Execution-cost calibration from realized fills.
+
+The live entry gates and equity accounting price every order with the
+configured @--slippage@ assumption. Real fills tell the truth: the average
+fill price (@cummulativeQuoteQty / executedQty@) versus the decision-bar
+close measures what crossing the book actually cost, including spread and
+short-horizon drift between decision and execution. This module turns those
+measurements into a calibrated per-side slippage estimate that replaces the
+static assumption once enough fills accumulate.
+
+The estimator is deliberately conservative:
+
+* the median of a bounded recent window (robust to fat-tailed fills),
+* shrunk toward the configured prior with weight @n / (n + k)@ — the same
+  shrinkage pattern used for combo live-performance blending,
+* floored at a fraction of the configured prior (good fills may relax the
+  gates only so far; underestimating costs is the dangerous direction),
+* capped absolutely so a run of terrible fills tightens gates rather than
+  producing a nonsensical cost model.
+
+The fee rate itself (@--fee@) is contractual and stays configured; only the
+uncertain price-impact component is calibrated.
+-}
+module Trader.CostCalibration (
+    calibratedSlippagePerSide,
+    costCalibrationFloorFactor,
+    costCalibrationMaxPerSide,
+    costCalibrationMinObservations,
+    costCalibrationOutlierBound,
+    costCalibrationShrinkageObs,
+    costCalibrationWindow,
+    observedSlippageFraction,
+) where
+
+import Data.List (sort)
+
+{- | Fills required before the calibrated estimate replaces the configured
+assumption (8 fills = roughly 4 round trips).
+-}
+costCalibrationMinObservations :: Int
+costCalibrationMinObservations = 8
+
+{- | Pseudo-count at which realized evidence carries the same weight as the
+configured prior (w = n / (n + k)).
+-}
+costCalibrationShrinkageObs :: Double
+costCalibrationShrinkageObs = 16
+
+{- | Only the most recent fills inform the estimate, so a venue's changing
+liquidity is tracked rather than averaged away.
+-}
+costCalibrationWindow :: Int
+costCalibrationWindow = 64
+
+{- | The calibrated estimate never drops below this fraction of the
+configured slippage: price improvement may relax gates, but not gut them.
+-}
+costCalibrationFloorFactor :: Double
+costCalibrationFloorFactor = 0.25
+
+{- | Absolute per-side ceiling (1%). Worse realized costs than this tighten
+gates at the cap rather than poisoning the cost model.
+-}
+costCalibrationMaxPerSide :: Double
+costCalibrationMaxPerSide = 0.01
+
+{- | Single-fill measurements beyond this magnitude (5%) are treated as data
+errors (bad decision price, corrupted fill) and discarded.
+-}
+costCalibrationOutlierBound :: Double
+costCalibrationOutlierBound = 0.05
+
+{- | Realized per-side slippage fraction of one fill: positive when the fill
+was worse than the decision price (paying up on a BUY, getting hit lower on
+a SELL), negative on price improvement. Nothing when the order didn't
+actually fill, any input is non-positive or non-finite, the side is
+unrecognized, or the measurement exceeds 'costCalibrationOutlierBound'.
+-}
+observedSlippageFraction :: String -> Double -> Maybe Double -> Maybe Double -> Maybe Double
+observedSlippageFraction side decisionPrice mExecutedQty mCumQuote = do
+    direction <-
+        case side of
+            "BUY" -> Just 1
+            "SELL" -> Just (-1)
+            _ -> Nothing
+    decision <- positiveFinite decisionPrice
+    qty <- mExecutedQty >>= positiveFinite
+    quote <- mCumQuote >>= positiveFinite
+    let avgFill = quote / qty
+        slip = direction * (avgFill - decision) / decision
+    if isNaN slip || isInfinite slip || abs slip > costCalibrationOutlierBound
+        then Nothing
+        else Just slip
+
+{- | Blend the configured per-side slippage with realized fill evidence
+(observations oldest-first). Below 'costCalibrationMinObservations' fills
+the configured value passes through untouched, so paper bots and fresh
+sessions behave exactly as before.
+-}
+calibratedSlippagePerSide :: Double -> [Double] -> Double
+calibratedSlippagePerSide configured observations =
+    let prior =
+            if isNaN configured || isInfinite configured || configured < 0
+                then 0
+                else configured
+        recent = takeLastObs costCalibrationWindow (filter finiteObs observations)
+        n = length recent
+     in if n < costCalibrationMinObservations
+            then prior
+            else
+                let est = median recent
+                    w = fromIntegral n / (fromIntegral n + costCalibrationShrinkageObs)
+                    blended = w * est + (1 - w) * prior
+                    floorVal = costCalibrationFloorFactor * prior
+                 in min costCalibrationMaxPerSide (max floorVal blended)
+  where
+    finiteObs x = not (isNaN x || isInfinite x)
+
+    takeLastObs k xs =
+        let len = length xs
+         in if len <= k then xs else drop (len - k) xs
+
+    median xs =
+        let sorted = sort xs
+            len = length sorted
+            mid = len `div` 2
+         in if len == 0
+                then 0
+                else
+                    if odd len
+                        then sorted !! mid
+                        else ((sorted !! (mid - 1)) + (sorted !! mid)) / 2
+
+positiveFinite :: Double -> Maybe Double
+positiveFinite x
+    | isNaN x || isInfinite x || x <= 0 = Nothing
+    | otherwise = Just x

--- a/haskell/app/Trader/LSTM.hs
+++ b/haskell/app/Trader/LSTM.hs
@@ -256,9 +256,10 @@ splitTrainVal valRatio xs
             splitAtN = max 1 (floor (fromIntegral n * (1 - valRatio)))
          in splitAt splitAtN xs
 
--- | The third argument is the input dimension @d@ (1 for the univariate
--- model). Datasets carry a per-sample loss weight; weight 1 everywhere is
--- exactly the unweighted MSE.
+{- | The third argument is the input dimension @d@ (1 for the univariate
+model). Datasets carry a per-sample loss weight; weight 1 everywhere is
+exactly the unweighted MSE.
+-}
 trainLoop :: LSTMConfig -> Int -> Int -> [(V.Vector Double, Double, Double)] -> [(V.Vector Double, Double, Double)] -> [Double] -> ([Double], [EpochStats])
 trainLoop cfg d hidden trainSet valSet initFlat =
     let beta1 = 0.9

--- a/haskell/app/Trader/LiveGap.hs
+++ b/haskell/app/Trader/LiveGap.hs
@@ -1,0 +1,158 @@
+{- | Live-vs-backtest gap analysis: the research optimizer's report card.
+
+The optimizer discovers combos by backtesting historical data; the fleet
+then trades them and accumulates a realized @live@ record per combo (see
+'Trader.TopCombosStore.ComboLiveStats'). The gap between realized and
+backtested annualized return, aggregated per method family, measures how
+much of each family's backtest edge survives contact with the market. A
+family whose combos chronically deliver less than they backtested is
+overfitting; one that holds up live deserves more of the discovery budget.
+
+The output is a per-method sampling multiplier the auto-optimizer applies
+to its discovery method weights. It is deliberately gentle: neutral (1.0)
+until a family has real live evidence, clamped to a bounded range so the
+feedback re-balances the search rather than slamming families on or off,
+and ops-weighted so one heavily-traded combo counts for more than ten
+barely-traded ones.
+-}
+module Trader.LiveGap (
+    LiveGapStats (..),
+    comboLiveGapEntry,
+    liveGapStatsByMethod,
+    liveGapMethodMultiplier,
+    liveGapMinComboOperations,
+    liveGapMinTotalOperations,
+    liveGapMultiplierFloor,
+    liveGapMultiplierCeiling,
+) where
+
+import Control.Applicative ((<|>))
+import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.Key as AK
+import qualified Data.Aeson.KeyMap as KM
+import Data.List (foldl')
+import qualified Data.Map.Strict as M
+import Data.Maybe (mapMaybe)
+import qualified Data.Text as T
+
+import Trader.TopCombosStore (
+    ComboLiveStats (..),
+    comboLiveStats,
+    comboMetricDouble,
+    comboMetricsDouble,
+ )
+
+{- | Live orders a single combo needs before its gap is a measurement
+rather than noise.
+-}
+liveGapMinComboOperations :: Int
+liveGapMinComboOperations = 10
+
+{- | Total live orders a method family needs before its multiplier moves
+off neutral.
+-}
+liveGapMinTotalOperations :: Int
+liveGapMinTotalOperations = 30
+
+{- | A chronically overfit family keeps at least a quarter of its discovery
+weight: the feedback re-balances the search, it doesn't kill exploration.
+-}
+liveGapMultiplierFloor :: Double
+liveGapMultiplierFloor = 0.25
+
+{- | A family that outperforms its backtests live earns at most 1.5x its
+base discovery weight.
+-}
+liveGapMultiplierCeiling :: Double
+liveGapMultiplierCeiling = 1.5
+
+{- | Per-method-family aggregation of live-vs-backtest gaps.
+'lgsOpsWeightedGap' is the operations-weighted mean of
+@liveAnnualizedReturn - backtestAnnualizedReturn@ across the family's
+combos (negative = the family delivers less live than it backtests).
+-}
+data LiveGapStats = LiveGapStats
+    { lgsCombos :: !Int
+    , lgsOperations :: !Int
+    , lgsOpsWeightedGap :: !Double
+    }
+    deriving (Eq, Show)
+
+{- | One combo's contribution: (method, live − backtest annualized return,
+live operation count). Nothing when the combo has no method, no live
+record with an annualized reading, or fewer than
+'liveGapMinComboOperations' live orders.
+-}
+comboLiveGapEntry :: Aeson.Value -> Maybe (String, Double, Int)
+comboLiveGapEntry val = do
+    method <- comboMethodString val
+    stats <- comboLiveStats val
+    liveAnn <- clsAnnualizedReturn stats
+    let ops = clsOperationCount stats
+    backtestAnn <-
+        comboMetricsDouble "annualizedReturn" val
+            <|> comboMetricDouble "annualizedReturn" val
+    let gap = liveAnn - backtestAnn
+    if ops < liveGapMinComboOperations || isNaN gap || isInfinite gap
+        then Nothing
+        else Just (method, gap, ops)
+
+comboMethodString :: Aeson.Value -> Maybe String
+comboMethodString val = do
+    paramsVal <- case val of
+        Aeson.Object o -> KM.lookup (AK.fromString "params") o
+        _ -> Nothing
+    paramsObj <- case paramsVal of
+        Aeson.Object p -> Just p
+        _ -> Nothing
+    methodVal <- KM.lookup (AK.fromString "method") paramsObj
+    case methodVal of
+        Aeson.String s ->
+            let trimmed = T.unpack (T.strip s)
+             in if null trimmed then Nothing else Just trimmed
+        _ -> Nothing
+
+-- | Aggregate gap evidence per method family from top-combos JSON values.
+liveGapStatsByMethod :: [Aeson.Value] -> M.Map String LiveGapStats
+liveGapStatsByMethod combos =
+    M.map finalize (foldl' step M.empty (mapMaybe comboLiveGapEntry combos))
+  where
+    -- During accumulation lgsOpsWeightedGap holds the weighted SUM;
+    -- 'finalize' divides it into the weighted mean.
+    step acc (method, gap, ops) =
+        M.insertWith
+            merge
+            method
+            LiveGapStats{lgsCombos = 1, lgsOperations = ops, lgsOpsWeightedGap = gap * fromIntegral ops}
+            acc
+    merge new old =
+        LiveGapStats
+            { lgsCombos = lgsCombos old + lgsCombos new
+            , lgsOperations = lgsOperations old + lgsOperations new
+            , lgsOpsWeightedGap = lgsOpsWeightedGap old + lgsOpsWeightedGap new
+            }
+    finalize s =
+        s
+            { lgsOpsWeightedGap =
+                if lgsOperations s > 0
+                    then lgsOpsWeightedGap s / fromIntegral (lgsOperations s)
+                    else 0
+            }
+
+{- | Discovery-weight multiplier for a method family. Neutral without
+evidence ('liveGapMinTotalOperations' live orders across the family), then
+@1 + gap@ clamped to ['liveGapMultiplierFloor', 'liveGapMultiplierCeiling']
+— a family losing 50 points of annualized return versus its backtests
+samples at half weight; beyond −75 points it bottoms out at the floor.
+-}
+liveGapMethodMultiplier :: Maybe LiveGapStats -> Double
+liveGapMethodMultiplier mStats =
+    case mStats of
+        Nothing -> 1
+        Just stats
+            | lgsOperations stats < liveGapMinTotalOperations -> 1
+            | isNaN (lgsOpsWeightedGap stats) || isInfinite (lgsOpsWeightedGap stats) -> 1
+            | otherwise ->
+                max
+                    liveGapMultiplierFloor
+                    (min liveGapMultiplierCeiling (1 + lgsOpsWeightedGap stats))

--- a/haskell/app/Trader/TopCombosStore.hs
+++ b/haskell/app/Trader/TopCombosStore.hs
@@ -24,6 +24,7 @@ module Trader.TopCombosStore (
     liveQuarantineMinOperations,
     liveQuarantineMaxFinalEquity,
     liveStatsQuarantined,
+    setComboLiveStats,
     isBinancePlatformKey,
     isCoinbasePlatformKey,
     isPoloniexPlatformKey,
@@ -387,8 +388,9 @@ data ComboLiveStats = ComboLiveStats
     }
     deriving (Eq, Show)
 
--- | Pseudo-count of live operations at which live evidence carries the same
--- weight as the backtest prior in the blended ranking (w = n / (n + k)).
+{- | Pseudo-count of live operations at which live evidence carries the same
+weight as the backtest prior in the blended ranking (w = n / (n + k)).
+-}
 liveBlendShrinkageOps :: Double
 liveBlendShrinkageOps = 25
 
@@ -452,8 +454,9 @@ comboLiveStatsFromObject obj = do
                     , clsLastAtMs = KM.lookup (AK.fromString "lastAtMs") liveObj >>= coerceInt64Value
                     }
 
--- | Read live stats from a combo JSON value (under @metrics.live@, falling
--- back to a root-level @live@ object).
+{- | Read live stats from a combo JSON value (under @metrics.live@, falling
+back to a root-level @live@ object).
+-}
 comboLiveStats :: Aeson.Value -> Maybe ComboLiveStats
 comboLiveStats val =
     (metricsObjectMaybe val >>= comboLiveStatsFromObject)
@@ -515,8 +518,9 @@ and survives merges instead of being silently re-added fresh.
 comboLiveQuarantined :: Aeson.Value -> Bool
 comboLiveQuarantined val = maybe False liveStatsQuarantined (comboLiveStats val)
 
--- | Write live stats into a combo's @metrics.live@, creating the metrics
--- object if needed.
+{- | Write live stats into a combo's @metrics.live@, creating the metrics
+object if needed.
+-}
 setComboLiveStats :: ComboLiveStats -> Aeson.Value -> Aeson.Value
 setComboLiveStats stats val =
     case val of
@@ -1120,10 +1124,11 @@ mergeTopCombosPayloadsWithStats maxItems now payloads =
             scoreVal = fromMaybe (negate (1 / 0))
             finalEqNew = fromMaybe 0 (comboFinalEquityValue newer)
             finalEqPrev = fromMaybe 0 (comboFinalEquityValue prev)
-            best =
-                if objNew == objPrev && (isJust scoreNew || isJust scorePrev)
-                    then if scoreVal scoreNew > scoreVal scorePrev then newer else prev
-                    else if finalEqNew > finalEqPrev then newer else prev
+            best
+                | objNew == objPrev && (isJust scoreNew || isJust scorePrev) =
+                    if scoreVal scoreNew > scoreVal scorePrev then newer else prev
+                | finalEqNew > finalEqPrev = newer
+                | otherwise = prev
          in preserveRichestLiveStats [newer, prev] best
 
     comboMetricString key val =

--- a/haskell/app/Trader/Trading.hs
+++ b/haskell/app/Trader/Trading.hs
@@ -521,8 +521,9 @@ the model corrects hardest exactly where its predictions cost money.
 outcomeWeightLossScale :: Double
 outcomeWeightLossScale = 25
 
--- | Ceiling on any single bar's outcome weight, so one extreme trade cannot
--- dominate the fine-tune window.
+{- | Ceiling on any single bar's outcome weight, so one extreme trade cannot
+dominate the fine-tune window.
+-}
 outcomeWeightCap :: Double
 outcomeWeightCap = 3
 

--- a/haskell/test/TestMain.hs
+++ b/haskell/test/TestMain.hs
@@ -6,6 +6,7 @@ module Main (main) where
 
 import Control.Exception (SomeException, evaluate, toException, try)
 import Control.Monad (forM_, unless)
+import Data.Aeson ((.=))
 import qualified Data.Aeson as Aeson
 import qualified Data.Aeson.Key as AK
 import qualified Data.Aeson.KeyMap as KM
@@ -13,7 +14,7 @@ import qualified Data.HashMap.Strict as HM
 import Data.Int (Int64)
 import Data.List (isInfixOf)
 import qualified Data.Map.Strict as Map
-import Data.Maybe (fromMaybe, isNothing)
+import Data.Maybe (catMaybes, fromMaybe, isNothing)
 import qualified Data.Text as T
 import qualified Data.Vector as V
 import Network.HTTP.Client (HttpException (..), HttpExceptionContent (..), parseRequest_, requestHeaders)
@@ -21,8 +22,15 @@ import Options.Applicative (ParserResult (..), auto, defaultPrefs, execParserPur
 import Trader.App.Args (Args (..), argRouterScorePnlWeight, argTunePenaltyTurnover, argWalkForwardEmbargoBars, argWalkForwardFolds, normalizeBarsForLookback, opts, parsePositioning, validateArgs)
 import Trader.App.Runtime (resolveTenantKeyFromParams, resolveTenantKeyFromPlatformParams, tenantKeyFromBinanceKeys, tenantKeyFromCoinbaseKeys)
 import Trader.Binance (FuturesPositionRisk (..), binanceExceptionSummary, futuresPositionRiskLeverageSane)
-import Trader.BotStartSemantics (botStartSymbolDisabled, botStartupBacktestAborts, botStartupBacktestRoiAcceptable, prioritizeBotStartSymbols, queuedStartOrderErrorIssue)
-import Trader.Coinbase (CoinbaseOrderInfo (..), decodeCoinbaseOrderInfo)
+import Trader.BotStartSemantics (BacktestVerdict (..), backtestVerdictAborts, botStartSymbolDisabled, botStartupBacktestAborts, botStartupBacktestRoiAcceptable, botStartupBacktestVerdict, prioritizeBotStartSymbols, queuedStartOrderErrorIssue)
+import Trader.Coinbase (CoinbaseCandle (..), CoinbaseOrderInfo (..), alignCoinbaseClosesToGrid, coinbaseProductFromBinance, decodeCoinbaseOrderInfo)
+import Trader.CostCalibration (
+    calibratedSlippagePerSide,
+    costCalibrationFloorFactor,
+    costCalibrationMaxPerSide,
+    costCalibrationMinObservations,
+    observedSlippageFraction,
+ )
 import Trader.Formal.Execution (
     ExecutionVerificationReport (..),
     verifyFormalExecution,
@@ -42,6 +50,17 @@ import Trader.Formal.Risk (
     verifyFormalRisk,
  )
 import Trader.GateTelemetry (GateName (..), GateRejection (..), GateTelemetry (..), RejectionReason (..), bindingGate, emptyTelemetry, recordRejection, rejectionHistogram, telemetrySummary, telemetryToJson)
+import Trader.LSTM (LSTMConfig (..), LSTMModel (..), buildSequences, evaluateLoss, fineTuneLSTM, fineTuneLSTMWeighted, inputDimFromModel, paramCount, paramCountD, predictNext, predictNextMulti, trainLSTM, trainLSTMMulti)
+import Trader.LiveGap (
+    LiveGapStats (..),
+    comboLiveGapEntry,
+    liveGapMethodMultiplier,
+    liveGapMinComboOperations,
+    liveGapMinTotalOperations,
+    liveGapMultiplierCeiling,
+    liveGapMultiplierFloor,
+    liveGapStatsByMethod,
+ )
 import Trader.MarketContext (fitLinearRange)
 import Trader.MarketDataIntegrity (
     isTransientMarketDataError,
@@ -76,14 +95,19 @@ import Trader.PredictionMarkets (
 import Trader.Predictors (RegimeProbs (..))
 import Trader.Predictors.Conformal (ConformalModel (..), fitConformal, predictInterval)
 import Trader.Predictors.Exogenous (alignToBars)
+import Trader.Predictors.Features (featuresAtWithInputsWithMarket, mkFeatureInputs, mkFeatureSpec, withCoinbaseInputs)
 import Trader.SignalGates (
     DirectionalitySnapshot (..),
+    PredictorLiveness (..),
     SignalThresholdBoundary (..),
     directionalityWeakBandConfirmed,
     directionalityWeakBandConfirmedWithPrediction,
+    dynamicRangePct,
     finiteDouble,
     mkSignalThresholdBoundary,
     normalizeSignalEntryEdge,
+    predictorDegenerate,
+    predictorLiveness,
     signalCrossAssetCheck,
     signalDirectionalitySnapshot,
     signalDirectionalitySnapshotImplWithPrediction,
@@ -106,13 +130,24 @@ import Trader.SignalGates (
     signalRegimeEdgeOk,
     signalRunPostDirectionGates,
  )
+import Trader.Test.AutoStartBackoff (autoStartBackoffSuite)
+import Trader.Test.BinanceProbe (binanceProbeSuite)
 import Trader.Test.TechnicalAnalysis (runTechnicalAnalysisTests)
 import Trader.ThresholdCalibration (CalibrationMethod (..), EdgeDistribution (..), ThresholdCalibration (..), calibrateThreshold, calibrationReport, calibrationToJson, computeEdgeDistribution, suggestedThreshold, thresholdAtPercentile)
 import Trader.TopCombosStore (
     ComboBacktestApplyStats (..),
     ComboBacktestUpdate (..),
+    ComboLiveStats (..),
     applyComboUpdatesWithStats,
+    blendedAnnualizedReturn,
     comboIdentityKey,
+    comboLiveQuarantined,
+    comboLiveStats,
+    comboLiveStatsFromObject,
+    comboPerformanceKey,
+    liveStatsQuarantined,
+    mergeTopCombosPayloads,
+    recalculateComboPerformanceFromOperation,
  )
 import Trader.Trading (
     BacktestCostAttribution (..),
@@ -136,10 +171,15 @@ import Trader.Trading (
     mkEntryGateState,
     mkTradingEntryGateInputs,
     needsEntry,
+    outcomeWeightCap,
+    outcomeWeightLossScale,
+    outcomeWeightWinScale,
     roundTripFeeFloor,
     simulateEnsemble,
     simulateEnsembleWithHLChecked,
     tradeEntrySourceCode,
+    tradeOutcomeWeightFactor,
+    tradeOutcomeWeights,
  )
 import Trader.VolConfGate (
     VolConfGateBehavior (..),
@@ -251,6 +291,24 @@ main = do
     testDisabledBotStartSymbols
     testBotStartupBacktestRoiAcceptability
     testBotStartupBacktestGuardFailOpen
+    testBotStartupBacktestVerdictZeroTradeIsNoVerdict
+    testBotStartupBacktestVerdictAbortOnLossWithTrades
+    testBotStartupBacktestVerdictPreservesDisabledBehaviour
+    testApplyComboUpdatesZeroTradeDoesNotPrune
+    testApplyComboUpdatesGenuineLossStillPrunes
+    testLiveBlendShrinkageRanking
+    testLiveQuarantineThresholds
+    testRecalculateMaintainsLiveStats
+    testBacktestUpdatePreservesLiveStats
+    testMergePreservesLiveStats
+    testTradeOutcomeWeightsSemantics
+    testWeightedFineTuneUnitWeightsEquivalence
+    testWeightedFineTunePunishesLossRegion
+    testObservedSlippageFractionSemantics
+    testCalibratedSlippageShrinkage
+    testLiveGapFeedback
+    testAlignToBarsPointInTime
+    testNormalizeBarsForLookbackBinanceClampsAtPageCap
     testBinanceExceptionSummaryRedactsSecrets
     testConformalCalibrationResidualsFailClosed
     testBacktestEntryGateUsesRoundTripFeeBuffer
@@ -289,29 +347,20 @@ main = do
     testFormalRiskPositionSizeHalt
     testFormalRiskLossStreakHalt
     testSignalGatesFailClosedExhaustive
-    testAlignToBarsPointInTime
+    testPredictorLivenessDetectsDegenerateForecast
+    testCrossExchangeCoinbaseInputs
+    testMultivariateLstmInputs
     runTechnicalAnalysisTests
+    runSuite "binanceProbe" binanceProbeSuite
+    runSuite "autoStartBackoff" autoStartBackoffSuite
 
-testAlignToBarsPointInTime :: IO ()
-testAlignToBarsPointInTime = do
-    let bars = V.fromList [1000, 2000, 3000 :: Int64]
-        intervalMs = 1000 :: Int64
-        -- Deliberately unsorted; (3500,30) is in the FUTURE relative to bars 0/1
-        -- (their closes are 1999 and 2999), so it must NOT influence them.
-        series = [(1500, 20.0), (500, 10.0), (3500, 30.0)]
-    assert
-        "alignToBars forward-fills point-in-time and never leaks future observations"
-        (alignToBars bars intervalMs series == V.fromList [Just 20.0, Just 20.0, Just 30.0])
-    assert
-        "alignToBars yields Nothing for bars before the first observation"
-        ( alignToBars (V.fromList [1000, 2000 :: Int64]) (1000 :: Int64) [(5000, 9.0)]
-            == V.fromList [Nothing, Nothing]
-        )
-    assert
-        "alignToBars carries the last value forward across gaps with no new data"
-        ( alignToBars (V.fromList [1000, 2000, 3000, 4000 :: Int64]) (1000 :: Int64) [(900, 7.0)]
-            == V.fromList [Just 7.0, Just 7.0, Just 7.0, Just 7.0]
-        )
+runSuite :: String -> [(String, IO ())] -> IO ()
+runSuite label cases =
+    forM_ cases $ \(name, run) -> do
+        result <- try run :: IO (Either SomeException ())
+        case result of
+            Left ex -> ioError (userError (label ++ " :: " ++ name ++ " failed: " ++ show ex))
+            Right () -> pure ()
 
 assert :: String -> Bool -> IO ()
 assert message condition =
@@ -320,6 +369,162 @@ assert message condition =
 assertMonotoneNonIncreasing :: String -> [Bool] -> IO ()
 assertMonotoneNonIncreasing message values =
     assert message (and (zipWith (\left right -> left || not right) values (drop 1 values)))
+
+{- | Regression for the 2026-06-02 silent zero-trade failure: an untrained
+forecaster pinned near a constant while price trends should be flagged
+degenerate, because its largest single-bar step cannot clear the entry
+threshold. A live forecaster, or any run that actually closed trades, must not
+be flagged.
+-}
+testPredictorLivenessDetectsDegenerateForecast :: IO ()
+testPredictorLivenessDetectsDegenerateForecast = do
+    let openThreshold = 0.0024 :: Double
+        -- Flat untrained forecast: ~94400 every bar, dynamic range ~7 over the
+        -- window, max consecutive step return ~1.1e-5 (observed shape).
+        flatSeries =
+            [Just (94400.0 + fromIntegral i * 1.0e-4) | i <- [0 .. 200 :: Int]] ++ [Nothing]
+        -- Live forecast: tracks a +20% move with multi-percent per-bar steps.
+        liveSeries =
+            map (Just . (94400.0 *)) (take 60 (iterate (* 1.01) 1.0)) ++ [Nothing]
+        -- Price dynamic range: simulate ~20% bull move akin to the bull dataset.
+        priceSeries =
+            map (Just . (94400.0 *)) (take 200 (iterate (* 1.001) 1.0))
+        priceRangePct = fromMaybe 0 (dynamicRangePct priceSeries)
+        flatLiveness = predictorLiveness "lstm" priceRangePct flatSeries
+        liveLiveness = predictorLiveness "lstm" priceRangePct liveSeries
+    assert
+        "price dynamic range is positive on a trending series"
+        (priceRangePct > 0.1)
+    case flatLiveness of
+        Just pl -> do
+            assert
+                "flat forecast max step return is far below the open threshold"
+                (plMaxStepReturn pl < openThreshold)
+            assert
+                "flat forecast dynamic range is negligible (<0.01%)"
+                (plDynamicRangePct pl < 1.0e-4)
+            assert
+                "flat forecast tracking ratio is below the 5% floor"
+                (plPriceTrackingRatio pl < 0.05)
+        Nothing -> assert "flat forecast should yield liveness diagnostics" False
+    case liveLiveness of
+        Just pl -> do
+            assert
+                "live forecast max step return clears the open threshold"
+                (plMaxStepReturn pl >= openThreshold)
+            assert
+                "live forecast tracking ratio is well above the 5% floor"
+                (plPriceTrackingRatio pl > 0.5)
+        Nothing -> assert "live forecast should yield liveness diagnostics" False
+    -- Zero closed trades + flat predictor => degenerate (structural no-trade).
+    assert
+        "degenerate flag fires for flat predictor with zero trades"
+        (predictorDegenerate 0 (catMaybes [flatLiveness]))
+    -- Any closed trade means the no-trade was a market decision, not structural.
+    assert
+        "degenerate flag is suppressed once trades close"
+        (not (predictorDegenerate 3 (catMaybes [flatLiveness])))
+    -- A live predictor that simply found no signal is not degenerate.
+    assert
+        "degenerate flag is suppressed for a live predictor"
+        (not (predictorDegenerate 0 (catMaybes [liveLiveness])))
+    -- No predictor series at all => nothing to assess => not degenerate.
+    assert
+        "degenerate flag is suppressed when no predictor series is present"
+        (not (predictorDegenerate 0 []))
+
+{- | Cross-exchange (Coinbase) input enrichment: symbol mapping, bar-grid
+alignment (point-in-time forward-fill, no lookahead), and the gated LSTM feature
+block (default off => identical vector; on => +5 same-asset features).
+-}
+testCrossExchangeCoinbaseInputs :: IO ()
+testCrossExchangeCoinbaseInputs = do
+    -- Symbol mapping: USD-pegged Binance quotes map to a Coinbase USD product.
+    assert "BTCUSDT -> BTC-USD" (coinbaseProductFromBinance "BTCUSDT" == Just "BTC-USD")
+    assert "ETHUSDC -> ETH-USD" (coinbaseProductFromBinance "ETHUSDC" == Just "ETH-USD")
+    assert "lower-case symbol still maps" (coinbaseProductFromBinance "btcusdt" == Just "BTC-USD")
+    assert "non-USD quote does not map" (isNothing (coinbaseProductFromBinance "ETHBTC"))
+
+    -- Alignment: exact match at matching open times, point-in-time forward-fill
+    -- for gaps, and NEVER a future bucket (bar at sec 120 must use 10, not 30).
+    let candle s c = CoinbaseCandle{ccOpenTime = s, ccHigh = c, ccLow = c, ccClose = c}
+        openTimesMs = [60000, 120000, 180000, 240000]
+        binanceCloses = V.fromList [1, 2, 3, 4]
+        aligned = alignCoinbaseClosesToGrid openTimesMs binanceCloses [candle 60 10, candle 180 30]
+    assert
+        "alignment forward-fills gaps without lookahead"
+        (aligned == Just (V.fromList [10, 10, 30, 30]))
+
+    -- Leading gap (before first Coinbase candle) falls back to the Binance close.
+    let leading = alignCoinbaseClosesToGrid openTimesMs binanceCloses [candle 180 30]
+    assert
+        "leading bars fall back to the Binance close"
+        (leading == Just (V.fromList [1, 2, 30, 30]))
+
+    -- No overlap at all => Nothing (caller fails open to Binance-only).
+    assert
+        "no Coinbase/Binance bar overlap yields Nothing"
+        (isNothing (alignCoinbaseClosesToGrid [60000, 120000] (V.fromList [1, 2]) [candle 999999 5]))
+
+    -- Feature gating: attaching a Coinbase close series appends exactly 5
+    -- same-asset features; absence is byte-identical to Binance-only.
+    let n = 60 :: Int
+        closes = V.fromList [100 + fromIntegral i * 0.5 | i <- [0 .. n - 1]]
+        fs = mkFeatureSpec 10
+        baseInputs = mkFeatureInputs closes Nothing Nothing Nothing Nothing
+        cbInputs = withCoinbaseInputs (Just (V.map (* 1.02) closes)) baseInputs
+        t = 40
+    case (featuresAtWithInputsWithMarket fs Nothing baseInputs t, featuresAtWithInputsWithMarket fs Nothing cbInputs t) of
+        (Just featsBase, Just featsCb) -> do
+            assert
+                "Coinbase attachment appends exactly 5 cross-exchange features"
+                (length featsCb == length featsBase + 5)
+            assert
+                "Binance-only feature vector is unchanged when Coinbase is absent"
+                (take (length featsBase) featsCb == featsBase)
+            let basisNow = featsCb !! length featsBase
+            assert
+                "basis feature reflects the ~+2% Coinbase premium"
+                (basisNow > 0.015 && basisNow < 0.025)
+        _ -> assert "feature vectors should be computable at t" False
+
+{- | Multivariate LSTM: a single channel is byte-identical to the univariate
+model (so the default/live path is unchanged), input dim is recoverable from the
+flat params, and a 2-channel (price + cross-exchange) model trains to a distinct,
+finite predictor that actually uses the second channel.
+-}
+testMultivariateLstmInputs :: IO ()
+testMultivariateLstmInputs = do
+    let cfg =
+            LSTMConfig
+                { lcLookback = 4
+                , lcHiddenSize = 3
+                , lcEpochs = 2
+                , lcLearningRate = 0.01
+                , lcValRatio = 0
+                , lcPatience = 0
+                , lcGradClip = Nothing
+                , lcSeed = 7
+                }
+        series = [0.10, 0.20, 0.15, 0.30, 0.25, 0.40, 0.35, 0.50, 0.45, 0.60, 0.55, 0.70, 0.65, 0.80]
+        series2 = [0.05, 0.10, 0.08, 0.20, 0.15, 0.25, 0.20, 0.30, 0.28, 0.35, 0.32, 0.45, 0.40, 0.50]
+        (mUni, _) = trainLSTM cfg series
+        (mMultiSingle, _) = trainLSTMMulti cfg [series]
+        (mMulti, _) = trainLSTMMulti cfg [series, series2]
+        window = take 4 series
+        finite x = not (isNaN x || isInfinite x)
+    -- d=1 identity: single-channel multivariate training matches univariate.
+    assert "single-channel multi training == univariate params" (lmParams mUni == lmParams mMultiSingle)
+    assert "univariate model input dim recovers as 1" (inputDimFromModel mUni == 1)
+    assert "univariate paramCount is consistent" (length (lmParams mUni) == paramCount (lmHiddenSize mUni))
+    assert
+        "predictNextMulti on a single channel == predictNext"
+        (abs (predictNextMulti mUni [window] - predictNext mUni window) < 1.0e-12)
+    -- d=2: trains a distinct, finite, dimension-2 model.
+    assert "two-channel model input dim recovers as 2" (inputDimFromModel mMulti == 2)
+    assert "two-channel paramCount matches paramCountD h 2" (length (lmParams mMulti) == paramCountD (lmHiddenSize mMulti) 2)
+    assert "two-channel params differ from univariate" (lmParams mMulti /= lmParams mUni)
+    assert "two-channel prediction is finite" (finite (predictNextMulti mMulti [take 4 series, take 4 series2]))
 
 topCombosCount :: Aeson.Value -> Int
 topCombosCount val =
@@ -2420,6 +2625,638 @@ testBotStartupBacktestGuardFailOpen = do
             && botStartupBacktestAborts True (Just (1 / 0))
             && botStartupBacktestAborts True (Just (0 / 0))
         )
+
+{- | H6 from 2026-06-10 review: a backtest that fired zero trades is not a
+verdict on the combo. It must produce 'BacktestNoVerdict' so the start is
+allowed and the combo is not pruned. Today's launchd log shows 124 such
+erroneous prunes with @finalEquity=1.000000@ exactly, all caused by
+zero-trade smoke windows. The verdict function is the central guard.
+-}
+testBotStartupBacktestVerdictZeroTradeIsNoVerdict :: IO ()
+testBotStartupBacktestVerdictZeroTradeIsNoVerdict = do
+    assert
+        "zero-trade backtest is not a verdict: do not abort, do not prune"
+        ( botStartupBacktestVerdict True (Just 1.0) (Just 0) == BacktestNoVerdict
+            && botStartupBacktestVerdict True (Just 0.9999) (Just 0) == BacktestNoVerdict
+            && botStartupBacktestVerdict True (Just 1.5) (Just 0) == BacktestAllow
+            -- An unknown tradeCount with a flat/losing finalEquity is also
+            -- not a verdict: we don't have evidence the smoke window
+            -- actually traded.
+            && botStartupBacktestVerdict True (Just 1.0) Nothing == BacktestNoVerdict
+            && not (backtestVerdictAborts BacktestNoVerdict)
+            && not (backtestVerdictAborts BacktestAllow)
+            && backtestVerdictAborts BacktestAbort
+        )
+
+{- | When the smoke backtest actually traded and lost (or finished flat with
+evidence of trading), the verdict must still abort — we don't want to fail
+open on a real signal that lost money.
+-}
+testBotStartupBacktestVerdictAbortOnLossWithTrades :: IO ()
+testBotStartupBacktestVerdictAbortOnLossWithTrades = do
+    assert
+        "backtest that traded and lost still aborts"
+        ( botStartupBacktestVerdict True (Just 0.5) (Just 4) == BacktestAbort
+            && botStartupBacktestVerdict True (Just 1.0) (Just 12) == BacktestAbort
+            && botStartupBacktestVerdict True (Just (1 / 0)) (Just 2) == BacktestAbort
+            && botStartupBacktestVerdict True (Just (0 / 0)) (Just 2) == BacktestAbort
+            -- One actual trade is enough evidence that the signal fired.
+            && botStartupBacktestVerdict True (Just 0.9) (Just 1) == BacktestAbort
+        )
+
+{- | The disabled-guard short-circuit (BotStartSemantics fail-open) must keep
+the new three-valued verdict consistent with the existing two-valued
+'botStartupBacktestAborts': disabled always allows, regardless of trades.
+-}
+testBotStartupBacktestVerdictPreservesDisabledBehaviour :: IO ()
+testBotStartupBacktestVerdictPreservesDisabledBehaviour = do
+    assert
+        "disabled guard always returns Allow and never aborts"
+        ( botStartupBacktestVerdict False (Just 0.5) (Just 4) == BacktestAllow
+            && botStartupBacktestVerdict False (Just 1.0) (Just 0) == BacktestAllow
+            && botStartupBacktestVerdict False Nothing Nothing == BacktestAllow
+            && botStartupBacktestVerdict False (Just (1 / 0)) Nothing == BacktestAllow
+            && not (backtestVerdictAborts (botStartupBacktestVerdict False (Just 0.0) (Just 99)))
+        )
+
+{- | End-to-end invariant on the JSON store: a zero-trade update must not
+cause 'applyComboUpdatesWithStats' to prune the combo. This closes the
+second prune path used by the optimizer top-N rerun.
+-}
+testApplyComboUpdatesZeroTradeDoesNotPrune :: IO ()
+testApplyComboUpdatesZeroTradeDoesNotPrune = do
+    let combosJson =
+            Aeson.object
+                [ "combos"
+                    .= Aeson.toJSON
+                        [ Aeson.object
+                            [ "comboKey" .= ("binance|BTCUSDT|15m|deadbeef" :: T.Text)
+                            , "platform" .= ("binance" :: T.Text)
+                            , "symbol" .= ("BTCUSDT" :: T.Text)
+                            , "interval" .= ("15m" :: T.Text)
+                            , "uuid" .= ("deadbeef-1234-5678-9abc-def012345678" :: T.Text)
+                            , "finalEquity" .= (1.42 :: Double)
+                            , "openThreshold" .= (0.005 :: Double)
+                            , "closeThreshold" .= (0.010 :: Double)
+                            , "objective" .= ("final-equity" :: T.Text)
+                            , "params"
+                                .= Aeson.object
+                                    [ "method" .= ("blend" :: T.Text)
+                                    , "lookback" .= (48 :: Int)
+                                    ]
+                            , "metrics"
+                                .= Aeson.object
+                                    [ "finalEquity" .= (1.42 :: Double)
+                                    , "tradeCount" .= (8 :: Int)
+                                    ]
+                            ]
+                        ]
+                ]
+    let firstCombo = case combosJson of
+            Aeson.Object o -> case KM.lookup "combos" o of
+                Just (Aeson.Array v) | not (V.null v) -> Just (V.head v)
+                _ -> Nothing
+            _ -> Nothing
+        key = case firstCombo >>= comboIdentityKey of
+            Just k -> k
+            Nothing -> error "test setup: combo identity key resolution failed"
+        zeroTradeUpdate =
+            ComboBacktestUpdate
+                { cbuMetrics =
+                    Aeson.object
+                        [ "finalEquity" .= (1.000000 :: Double)
+                        , "tradeCount" .= (0 :: Int)
+                        ]
+                , cbuFinalEquity = Just 1.0
+                , cbuScore = Just 0.0
+                , cbuOperations = Nothing
+                }
+        result = applyComboUpdatesWithStats 0 (HM.singleton key zeroTradeUpdate) combosJson
+    case result of
+        Left err -> ioError (userError ("applyComboUpdatesWithStats failed unexpectedly: " ++ err))
+        Right (_, stats) ->
+            assert
+                "zero-trade smoke update does not prune the combo"
+                (cbasUpdatedCount stats == 1 && cbasPrunedCount stats == 0 && null (cbasPrunedKeys stats))
+
+{- | Symmetry test for the prune fix: a genuine loss (positive trade count,
+sub-threshold finalEquity) must still prune. We don't want the fix to
+swallow real signal regressions.
+-}
+testApplyComboUpdatesGenuineLossStillPrunes :: IO ()
+testApplyComboUpdatesGenuineLossStillPrunes = do
+    let combosJson =
+            Aeson.object
+                [ "combos"
+                    .= Aeson.toJSON
+                        [ Aeson.object
+                            [ "comboKey" .= ("binance|ETHUSDT|15m|cafebabe" :: T.Text)
+                            , "platform" .= ("binance" :: T.Text)
+                            , "symbol" .= ("ETHUSDT" :: T.Text)
+                            , "interval" .= ("15m" :: T.Text)
+                            , "uuid" .= ("cafebabe-1234-5678-9abc-def012345678" :: T.Text)
+                            , "finalEquity" .= (1.42 :: Double)
+                            , "openThreshold" .= (0.005 :: Double)
+                            , "closeThreshold" .= (0.010 :: Double)
+                            , "objective" .= ("final-equity" :: T.Text)
+                            , "params"
+                                .= Aeson.object
+                                    [ "method" .= ("blend" :: T.Text)
+                                    , "lookback" .= (48 :: Int)
+                                    ]
+                            , "metrics"
+                                .= Aeson.object
+                                    [ "finalEquity" .= (1.42 :: Double)
+                                    , "tradeCount" .= (8 :: Int)
+                                    ]
+                            ]
+                        ]
+                ]
+    let firstCombo = case combosJson of
+            Aeson.Object o -> case KM.lookup "combos" o of
+                Just (Aeson.Array v) | not (V.null v) -> Just (V.head v)
+                _ -> Nothing
+            _ -> Nothing
+        key = case firstCombo >>= comboIdentityKey of
+            Just k -> k
+            Nothing -> error "test setup: combo identity key resolution failed"
+        lossUpdate =
+            ComboBacktestUpdate
+                { cbuMetrics =
+                    Aeson.object
+                        [ "finalEquity" .= (0.85 :: Double)
+                        , "tradeCount" .= (12 :: Int)
+                        ]
+                , cbuFinalEquity = Just 0.85
+                , cbuScore = Just (-0.15)
+                , cbuOperations = Nothing
+                }
+        result = applyComboUpdatesWithStats 0 (HM.singleton key lossUpdate) combosJson
+    case result of
+        Left err -> ioError (userError ("applyComboUpdatesWithStats failed unexpectedly: " ++ err))
+        Right (_, stats) ->
+            assert
+                "genuine loss with positive tradeCount still prunes"
+                (cbasUpdatedCount stats == 1 && cbasPrunedCount stats == 1 && length (cbasPrunedKeys stats) == 1)
+
+liveStatsForTest :: Double -> Maybe Double -> Int -> Aeson.Value
+liveStatsForTest eq mAnn count =
+    Aeson.object
+        ( [ "finalEquity" .= eq
+          , "operationCount" .= count
+          ]
+            ++ maybe [] (\ann -> ["annualizedReturn" .= ann]) mAnn
+        )
+
+liveComboForTest :: T.Text -> Double -> Maybe Aeson.Value -> Aeson.Value
+liveComboForTest sym backtestAnn mLive =
+    Aeson.object
+        [ "symbol" .= sym
+        , "uuid" .= ("0badc0de-1234-5678-9abc-def012345678" :: T.Text)
+        , "finalEquity" .= (1.4 :: Double)
+        , "annualizedReturn" .= backtestAnn
+        , "openThreshold" .= (0.005 :: Double)
+        , "closeThreshold" .= (0.010 :: Double)
+        , "objective" .= ("final-equity" :: T.Text)
+        , "params" .= Aeson.object ["method" .= ("blend" :: T.Text)]
+        , "metrics"
+            .= Aeson.object
+                ( ["finalEquity" .= (1.4 :: Double), "tradeCount" .= (8 :: Int)]
+                    ++ maybe [] (\live -> ["live" .= live]) mLive
+                )
+        ]
+
+{- | Live evidence shifts the ranking via shrinkage: with n live orders the
+live annualized return carries weight n/(n+25), so a combo whose live record
+contradicts its backtest sinks below an identical combo with no live history,
+but a thin live record (small n) barely moves the needle.
+-}
+testLiveBlendShrinkageRanking :: IO ()
+testLiveBlendShrinkageRanking = do
+    let halfWeightStats =
+            ComboLiveStats
+                { clsFinalEquity = 1.0
+                , clsAnnualizedReturn = Just 0.0
+                , clsOperationCount = 25
+                , clsFirstAtMs = Nothing
+                , clsLastAtMs = Nothing
+                }
+    assert
+        "n = shrinkage pseudo-count gives live evidence exactly half weight"
+        (abs (blendedAnnualizedReturn 2.0 (Just halfWeightStats) - 1.0) < 1e-9)
+    assert
+        "no live stats leaves the backtest prior untouched"
+        (blendedAnnualizedReturn 2.0 Nothing == 2.0)
+    let noLive = liveComboForTest "BTCUSDT" 2.0 Nothing
+        liveBreakEven = liveComboForTest "BTCUSDT" 2.0 (Just (liveStatsForTest 1.0 (Just 0.0) 25))
+        liveThin = liveComboForTest "BTCUSDT" 2.0 (Just (liveStatsForTest 1.0 (Just 0.0) 1))
+    assert
+        "live break-even record ranks an identical combo lower"
+        (comboPerformanceKey liveBreakEven > comboPerformanceKey noLive)
+    assert
+        "a thin live record moves the rank less than a substantial one"
+        (comboPerformanceKey liveThin < comboPerformanceKey liveBreakEven)
+
+testLiveQuarantineThresholds :: IO ()
+testLiveQuarantineThresholds = do
+    let stats eq count =
+            ComboLiveStats
+                { clsFinalEquity = eq
+                , clsAnnualizedReturn = Just (-0.5)
+                , clsOperationCount = count
+                , clsFirstAtMs = Nothing
+                , clsLastAtMs = Nothing
+                }
+    assert "below minimum live orders never quarantines" (not (liveStatsQuarantined (stats 0.5 29)))
+    assert "sustained live loss quarantines" (liveStatsQuarantined (stats 0.98 30))
+    assert "live winner is not quarantined" (not (liveStatsQuarantined (stats 1.05 30)))
+    let quarantined = liveComboForTest "ETHUSDT" 3.0 (Just (liveStatsForTest 0.9 (Just (-0.5)) 40))
+        modest = liveComboForTest "ETHUSDT" 0.1 Nothing
+    assert "combo-level quarantine flag reads from metrics.live" (comboLiveQuarantined quarantined)
+    assert
+        "quarantined combo sinks below any healthy combo regardless of backtest"
+        (comboPerformanceKey quarantined > comboPerformanceKey modest)
+
+{- | 'recalculateComboPerformanceFromOperation' must accumulate a separate
+live record (compounded equity, order count, span) alongside the blended
+backtest fields it already maintains, and only annualize once the observed
+span is long enough to be meaningful.
+-}
+testRecalculateMaintainsLiveStats :: IO ()
+testRecalculateMaintainsLiveStats = do
+    let t0 = 1700000000000 :: Int64
+        (_, _, metrics1) =
+            recalculateComboPerformanceFromOperation t0 (Just "1h") (Just 1.42) (Just 0.8) KM.empty Nothing 1.05
+    stats1 <- case comboLiveStatsFromObject metrics1 of
+        Nothing -> ioError (userError "first operation did not create a live record")
+        Just s -> pure s
+    assert "first operation seeds the live record" (clsOperationCount stats1 == 1)
+    assert "first operation compounds live equity from the order ratio" (abs (clsFinalEquity stats1 - 1.05) < 1e-9)
+    assert "first operation pins the live span start" (clsFirstAtMs stats1 == Just t0)
+    assert "no annualization before a meaningful live span" (isNothing (clsAnnualizedReturn stats1))
+    let t1 = t0 + 2 * 86400000
+        (_, _, metrics2) =
+            recalculateComboPerformanceFromOperation t1 (Just "1h") (Just 1.49) (Just 0.8) metrics1 (Just 1.05) 0.945
+    stats2 <- case comboLiveStatsFromObject metrics2 of
+        Nothing -> ioError (userError "second operation lost the live record")
+        Just s -> pure s
+    assert "second operation increments the live order count" (clsOperationCount stats2 == 2)
+    assert "live equity compounds across operations" (abs (clsFinalEquity stats2 - 0.945) < 1e-9)
+    assert "live span start is preserved" (clsFirstAtMs stats2 == Just t0)
+    assert "live span end tracks the latest operation" (clsLastAtMs stats2 == Just t1)
+    assert
+        "a losing live record annualizes negative (clamped)"
+        (maybe False (<= (-0.99)) (clsAnnualizedReturn stats2))
+
+{- | A scheduled re-backtest replaces a combo's metrics wholesale; the
+accumulated live record must survive that refresh or the system forgets
+everything it learned from its own orders every 24h.
+-}
+testBacktestUpdatePreservesLiveStats :: IO ()
+testBacktestUpdatePreservesLiveStats = do
+    let combo = liveComboForTest "BTCUSDT" 1.2 (Just (liveStatsForTest 1.1 (Just 0.4) 12))
+        combosJson = Aeson.object ["combos" .= [combo]]
+        key = case comboIdentityKey combo of
+            Just k -> k
+            Nothing -> error "test setup: combo identity key resolution failed"
+        update =
+            ComboBacktestUpdate
+                { cbuMetrics =
+                    Aeson.object
+                        [ "finalEquity" .= (1.3 :: Double)
+                        , "tradeCount" .= (10 :: Int)
+                        ]
+                , cbuFinalEquity = Just 1.3
+                , cbuScore = Just 0.3
+                , cbuOperations = Nothing
+                }
+    case applyComboUpdatesWithStats 0 (HM.singleton key update) combosJson of
+        Left err -> ioError (userError ("applyComboUpdatesWithStats failed unexpectedly: " ++ err))
+        Right (updatedVal, _) -> do
+            let mUpdatedCombo = case updatedVal of
+                    Aeson.Object o -> case KM.lookup "combos" o of
+                        Just (Aeson.Array v) | not (V.null v) -> Just (V.head v)
+                        _ -> Nothing
+                    _ -> Nothing
+            stats <- case mUpdatedCombo >>= comboLiveStats of
+                Nothing -> ioError (userError "backtest refresh erased the live record")
+                Just s -> pure s
+            assert "live record survives a backtest metrics refresh" (clsOperationCount stats == 12)
+
+{- | The S3 combo bus merges payloads from multiple instances; whichever
+duplicate wins the merge must carry the richest live record seen across all
+of them, so live evidence is never lost in transit between instances.
+-}
+testMergePreservesLiveStats :: IO ()
+testMergePreservesLiveStats = do
+    let comboWithLive = liveComboForTest "BTCUSDT" 1.2 (Just (liveStatsForTest 1.1 (Just 0.4) 10))
+        comboFresh =
+            case liveComboForTest "BTCUSDT" 1.2 Nothing of
+                Aeson.Object o -> Aeson.Object (KM.insert "score" (Aeson.toJSON (0.9 :: Double)) o)
+                v -> v
+        payload combosVal generatedAt =
+            Aeson.object
+                [ "combos" .= [combosVal]
+                , "generatedAtMs" .= (generatedAt :: Int64)
+                , "source" .= ("test" :: T.Text)
+                ]
+        merged = mergeTopCombosPayloads 10 2000 [payload comboWithLive 1000, payload comboFresh 1500]
+        mMergedCombo = case merged of
+            Aeson.Object o -> case KM.lookup "combos" o of
+                Just (Aeson.Array v) | not (V.null v) -> Just (V.head v)
+                _ -> Nothing
+            _ -> Nothing
+    case mMergedCombo of
+        Nothing -> ioError (userError "merge produced no combos")
+        Just mergedCombo -> do
+            stats <- case comboLiveStats mergedCombo of
+                Nothing -> ioError (userError "merge dropped the live record")
+                Just s -> pure s
+            assert "merge keeps the richest live record across duplicates" (clsOperationCount stats == 10)
+
+mkOutcomeTestTrade :: Int -> Int -> Double -> Trade
+mkOutcomeTestTrade entryIdx exitIdx ret =
+    Trade
+        { trEntryIndex = entryIdx
+        , trExitIndex = exitIdx
+        , trEntryEquity = 1.0
+        , trExitEquity = 1.0 + ret
+        , trReturn = ret
+        , trHoldingPeriods = exitIdx - entryIdx
+        , trEntryHighVolProb = Nothing
+        , trEntrySource = TradeEntrySignal
+        , trExitReason = Nothing
+        , trEntryIp = Nothing
+        , trExitIp = Nothing
+        , trFeeCost = 0.0
+        }
+
+{- | Outcome weights translate closed trades into per-bar loss emphasis for
+the LSTM fine-tune: losing spans weigh more than winning spans (asymmetric
+scales), uncovered bars stay at 1, and a cap bounds any single trade's
+influence.
+-}
+testTradeOutcomeWeightsSemantics :: IO ()
+testTradeOutcomeWeightsSemantics = do
+    let win = mkOutcomeTestTrade 2 4 0.02
+        loss = mkOutcomeTestTrade 6 7 (-0.02)
+        weights = tradeOutcomeWeights [win, loss] 10
+    assert "weights align index-for-index with the series" (length weights == 10)
+    assert "bars not covered by any trade weigh 1" (all (\t -> weights !! t == 1.0) [0, 1, 5, 8, 9])
+    assert
+        "a winning trade reinforces its span (1 + winScale * |return|)"
+        (all (\t -> abs (weights !! t - (1 + outcomeWeightWinScale * 0.02)) < 1e-9) [2 .. 4])
+    assert
+        "a losing trade punishes its span harder (1 + lossScale * |return|)"
+        (all (\t -> abs (weights !! t - (1 + outcomeWeightLossScale * 0.02)) < 1e-9) [6, 7])
+    assert
+        "loss scale exceeds win scale"
+        (outcomeWeightLossScale > outcomeWeightWinScale)
+    assert
+        "extreme trades cap at outcomeWeightCap"
+        (tradeOutcomeWeightFactor (mkOutcomeTestTrade 0 1 (-0.5)) == Just outcomeWeightCap)
+    assert
+        "break-even trades carry no learning signal"
+        (isNothing (tradeOutcomeWeightFactor (mkOutcomeTestTrade 0 1 0)))
+    assert
+        "trade spans clamp to the series bounds"
+        (last (tradeOutcomeWeights [mkOutcomeTestTrade 8 20 (-0.02)] 10) > 1)
+    assert "empty series yields no weights" (null (tradeOutcomeWeights [win] 0))
+
+{- | The weighted fine-tune with default weights must be exactly the plain
+fine-tune, so enabling outcome weighting cannot perturb bots with no
+closed trades.
+-}
+testWeightedFineTuneUnitWeightsEquivalence :: IO ()
+testWeightedFineTuneUnitWeightsEquivalence = do
+    let series = [0.5 + 0.2 * sin (fromIntegral t / 5) | t <- [0 .. 59 :: Int]]
+        cfg =
+            LSTMConfig
+                { lcLookback = 4
+                , lcHiddenSize = 4
+                , lcEpochs = 8
+                , lcLearningRate = 0.01
+                , lcValRatio = 0
+                , lcPatience = 0
+                , lcGradClip = Nothing
+                , lcSeed = 7
+                }
+        (model0, _) = trainLSTM cfg{lcEpochs = 0} series
+        (plain, _) = fineTuneLSTM cfg model0 series
+        (weightedEmpty, _) = fineTuneLSTMWeighted cfg model0 series []
+        (weightedOnes, _) = fineTuneLSTMWeighted cfg model0 series (replicate 60 1.0)
+    assert "no weights reproduces the plain fine-tune bit-for-bit" (lmParams weightedEmpty == lmParams plain)
+    assert "unit weights reproduce the plain fine-tune bit-for-bit" (lmParams weightedOnes == lmParams plain)
+
+testAlignToBarsPointInTime :: IO ()
+testAlignToBarsPointInTime = do
+    let bars = V.fromList [1000, 2000, 3000 :: Int64]
+        intervalMs = 1000 :: Int64
+        -- Deliberately unsorted; (3500,30) is in the FUTURE relative to bars 0/1
+        -- (their closes are 1999 and 2999), so it must NOT influence them.
+        series = [(1500, 20.0), (500, 10.0), (3500, 30.0)]
+    assert
+        "alignToBars forward-fills point-in-time and never leaks future observations"
+        (alignToBars bars intervalMs series == V.fromList [Just 20.0, Just 20.0, Just 30.0])
+    assert
+        "alignToBars yields Nothing for bars before the first observation"
+        ( alignToBars (V.fromList [1000, 2000 :: Int64]) (1000 :: Int64) [(5000, 9.0)]
+            == V.fromList [Nothing, Nothing]
+        )
+    assert
+        "alignToBars carries the last value forward across gaps with no new data"
+        ( alignToBars (V.fromList [1000, 2000, 3000, 4000 :: Int64]) (1000 :: Int64) [(900, 7.0)]
+            == V.fromList [Just 7.0, Just 7.0, Just 7.0, Just 7.0]
+        )
+
+gapComboForTest :: T.Text -> Double -> Double -> Int -> Aeson.Value
+gapComboForTest method backtestAnn liveAnn ops =
+    Aeson.object
+        [ "annualizedReturn" .= backtestAnn
+        , "params" .= Aeson.object ["method" .= method]
+        , "metrics"
+            .= Aeson.object
+                [ "live"
+                    .= Aeson.object
+                        [ "finalEquity" .= (1.0 :: Double)
+                        , "operationCount" .= ops
+                        , "annualizedReturn" .= liveAnn
+                        ]
+                ]
+        ]
+
+{- | The optimizer's report card: per-combo live-vs-backtest gap entries
+require real live evidence, aggregate ops-weighted per method family, and
+map to a bounded discovery-sampling multiplier.
+-}
+testLiveGapFeedback :: IO ()
+testLiveGapFeedback = do
+    let entry = comboLiveGapEntry (gapComboForTest "10" 2.0 0.5 12)
+    assert
+        "a combo with live evidence yields (method, live - backtest, ops)"
+        (entry == Just ("10", -1.5, 12))
+    assert
+        "too few live orders yields no gap entry"
+        (isNothing (comboLiveGapEntry (gapComboForTest "10" 2.0 0.5 (liveGapMinComboOperations - 1))))
+    assert
+        "a combo without a live record yields no gap entry"
+        ( isNothing
+            ( comboLiveGapEntry
+                (Aeson.object ["annualizedReturn" .= (2.0 :: Double), "params" .= Aeson.object ["method" .= ("10" :: T.Text)]])
+            )
+        )
+    let statsMap =
+            liveGapStatsByMethod
+                [ gapComboForTest "10" 1.0 0.0 30 -- gap -1, 30 ops
+                , gapComboForTest "10" 1.0 2.0 10 -- gap +1, 10 ops
+                , gapComboForTest "01" 3.0 0.0 40 -- separate family
+                ]
+    case Map.lookup "10" statsMap of
+        Nothing -> ioError (userError "method 10 missing from gap stats")
+        Just s -> do
+            assert "family aggregates combos and operations" (lgsCombos s == 2 && lgsOperations s == 40)
+            assert
+                "the family gap is operations-weighted"
+                (abs (lgsOpsWeightedGap s - ((-1) * 30 + 1 * 10) / 40) < 1e-9)
+    assert "families aggregate separately" (Map.member "01" statsMap && Map.size statsMap == 2)
+    let statsWith gap ops = LiveGapStats{lgsCombos = 3, lgsOperations = ops, lgsOpsWeightedGap = gap}
+    assert "no evidence is neutral" (liveGapMethodMultiplier Nothing == 1)
+    assert
+        "below the family evidence floor is neutral"
+        (liveGapMethodMultiplier (Just (statsWith (-2) (liveGapMinTotalOperations - 1))) == 1)
+    assert
+        "a moderate live shortfall scales sampling down proportionally"
+        (abs (liveGapMethodMultiplier (Just (statsWith (-0.5) 60)) - 0.5) < 1e-9)
+    assert
+        "a chronic shortfall bottoms out at the floor, never zero"
+        (liveGapMethodMultiplier (Just (statsWith (-3) 60)) == liveGapMultiplierFloor)
+    assert
+        "live outperformance caps at the ceiling"
+        (liveGapMethodMultiplier (Just (statsWith 2 60)) == liveGapMultiplierCeiling)
+    assert
+        "mild outperformance earns a proportional boost"
+        (abs (liveGapMethodMultiplier (Just (statsWith 0.2 60)) - 1.2) < 1e-9)
+
+{- | Fill measurements: positive when execution was worse than the decision
+price on either side, negative on improvement, Nothing whenever the inputs
+cannot support an honest measurement.
+-}
+testObservedSlippageFractionSemantics :: IO ()
+testObservedSlippageFractionSemantics = do
+    let approx expected = maybe False (\v -> abs (v - expected) < 1e-12)
+    assert
+        "BUY filled above the decision price is a positive cost"
+        (approx 0.005 (observedSlippageFraction "BUY" 100 (Just 2) (Just 201)))
+    assert
+        "SELL filled below the decision price is a positive cost"
+        (approx 0.005 (observedSlippageFraction "SELL" 100 (Just 2) (Just 199)))
+    assert
+        "price improvement measures negative"
+        (approx (-0.005) (observedSlippageFraction "BUY" 100 (Just 2) (Just 199)))
+    assert
+        "unknown side measures nothing"
+        (isNothing (observedSlippageFraction "HOLD" 100 (Just 2) (Just 201)))
+    assert
+        "unfilled orders measure nothing"
+        ( isNothing (observedSlippageFraction "BUY" 100 Nothing (Just 201))
+            && isNothing (observedSlippageFraction "BUY" 100 (Just 0) (Just 201))
+        )
+    assert
+        "non-positive decision price measures nothing"
+        (isNothing (observedSlippageFraction "BUY" 0 (Just 2) (Just 201)))
+    assert
+        "implausible measurements are rejected as data errors"
+        (isNothing (observedSlippageFraction "BUY" 100 (Just 2) (Just 212)))
+
+{- | The calibration must stay at the configured assumption until enough
+fills accumulate, then move toward realized costs with shrinkage, and obey
+the floor (price improvement can't gut the gates) and the absolute cap.
+-}
+testCalibratedSlippageShrinkage :: IO ()
+testCalibratedSlippageShrinkage = do
+    let configured = 0.0002
+    assert
+        "below the minimum observation count the configured value passes through"
+        (calibratedSlippagePerSide configured (replicate (costCalibrationMinObservations - 1) 0.003) == configured)
+    assert
+        "non-finite observations don't count toward the minimum"
+        ( calibratedSlippagePerSide
+            configured
+            (replicate (costCalibrationMinObservations - 1) 0.003 ++ [0 / 0, 1 / 0])
+            == configured
+        )
+    let calibratedUp = calibratedSlippagePerSide configured (replicate 32 0.003)
+    assert
+        "sustained worse fills raise the estimate above the configured prior"
+        (calibratedUp > configured && calibratedUp < 0.003)
+    let floored = calibratedSlippagePerSide configured (replicate 32 (-0.004))
+    assert
+        "price improvement floors at a fraction of the configured prior"
+        (abs (floored - costCalibrationFloorFactor * configured) < 1e-12)
+    assert
+        "catastrophic fills cap at the absolute per-side ceiling"
+        (calibratedSlippagePerSide configured (replicate 64 0.045) == costCalibrationMaxPerSide)
+    assert
+        "calibration moves monotonically with more evidence"
+        ( calibratedSlippagePerSide configured (replicate 8 0.003)
+            < calibratedSlippagePerSide configured (replicate 64 0.003)
+        )
+
+{- | The reinforcement semantics: starting from identical parameters, a
+fine-tune that upweights one region of the series must fit that region
+better than the uniformly-weighted fine-tune does — that is what makes a
+losing trade's span actually correct the model.
+-}
+testWeightedFineTunePunishesLossRegion :: IO ()
+testWeightedFineTunePunishesLossRegion = do
+    let n = 40 :: Int
+        lookback = 3
+        hidden = 4
+        regionB t = t >= 20
+        series = [if regionB t then 0.8 else 0.2 | t <- [0 .. n - 1]]
+        cfg =
+            LSTMConfig
+                { lcLookback = lookback
+                , lcHiddenSize = hidden
+                , lcEpochs = 40
+                , lcLearningRate = 0.02
+                , lcValRatio = 0
+                , lcPatience = 0
+                , lcGradClip = Nothing
+                , lcSeed = 11
+                }
+        (model0, _) = trainLSTM cfg{lcEpochs = 0} series
+        (uniform, _) = fineTuneLSTM cfg model0 series
+        weights = [if regionB t then 8 else 1 | t <- [0 .. n - 1]]
+        (weighted, _) = fineTuneLSTMWeighted cfg model0 series weights
+        dataset = buildSequences lookback series
+        regionBSamples = [s | (i, s) <- zip [0 :: Int ..] dataset, regionB (i + lookback)]
+        lossOn model = evaluateLoss lookback hidden regionBSamples (lmParams model)
+    assert "test setup: the emphasized region has samples" (not (null regionBSamples))
+    assert
+        "upweighting a region trains it to a better fit than uniform weighting"
+        (lossOn weighted < lossOn uniform)
+
+{- | Today's launchd log also showed:
+  @Need at least 3361 price rows for lookback=3360 (got 500) from Binance FILUSDT (3m)@
+and the same for XRPUSDT. The current behaviour of 'normalizeBarsForLookback'
+is to leave 'argBars' alone when @requiredBars > 1000@. That is the right
+conservative call for now (paging is the optimizer's job, not the bot
+starter's). This test pins that decision so any future change is
+deliberate, with an explicit follow-up reminder.
+-}
+testNormalizeBarsForLookbackBinanceClampsAtPageCap :: IO ()
+testNormalizeBarsForLookbackBinanceClampsAtPageCap = do
+    let parseOrFail argv =
+            case parseCliArgs argv of
+                Left err -> ioError (userError ("CLI parse failed unexpectedly: " ++ err))
+                Right a -> pure a
+    overLookbackArgs <-
+        parseOrFail ["--binance-symbol", "FILUSDT", "--interval", "3m", "--bars", "500", "--lookback-bars", "3360"]
+    let adjusted = normalizeBarsForLookback overLookbackArgs
+    assert
+        "Binance + requiredBars > 1000 leaves --bars unchanged (deferred: page or shrink lookback in optimizer)"
+        (argBars adjusted == argBars overLookbackArgs)
 
 testBinanceExceptionSummaryRedactsSecrets :: IO ()
 testBinanceExceptionSummaryRedactsSecrets = do

--- a/haskell/trader.cabal
+++ b/haskell/trader.cabal
@@ -20,6 +20,8 @@ executable trader-hs
                      , Trader.Coinbase
                      , Trader.ComboTracking
                      , Trader.Config
+                     , Trader.CostCalibration
+                     , Trader.LiveGap
                      , Trader.Cors
                      , Trader.Dex
                      , Trader.App.Args
@@ -228,6 +230,8 @@ test-suite trader-tests
                      , Trader.Coinbase
                      , Trader.ComboTracking
                      , Trader.Config
+                     , Trader.CostCalibration
+                     , Trader.LiveGap
                      , Trader.Cors
                      , Trader.Dex
                      , Trader.App.Args


### PR DESCRIPTION
## Why main is broken

CI on main fails to build (`Main.hs:3927`: missing argument to `recalculateComboPerformanceFromOperation`). The autoloop's merge of `feat/research-harness` into main (`d2079d1f` → `aca8d15a`) resolved conflicts inconsistently: it kept the branch's `TopCombosStore` (new 8-arg signature, live-stats blending) but resolved large regions of `Main.hs` and `TestMain.hs` back to pre-branch hunks.

Beyond the compile error, that resolution **silently dropped working, tested functionality**:

- all combo live-performance wiring in `Main.hs` (live-stats annotation, quarantine filters at bot-start selection, live-record preservation in the DB upsert)
- the outcome-weighted LSTM fine-tune call
- the bot-startup zero-trade smoke-window fix from `47a34846` (reverted to the old abort API)
- ~15 test functions (~700 lines), including the learning-loop and cross-exchange suites

Patching only the call site would compile but ship dead learning loops — hence a full restoration.

## What this PR does

- Restores `Main.hs`, `TestMain.hs`, `TopCombosStore.hs`, `Trading.hs` from the branch tip, which also brings in the two newest loops (`Trader.CostCalibration`, `Trader.LiveGap`, commit `907040fb`)
- Keeps all main-only work: Exogenous predictor modules, Binance changes, style-formatted `LSTM.hs`
- Re-adds main's `testAlignToBarsPointInTime` and the Exogenous cabal entries (union, nothing lost from either side)
- fourmolu + hlint clean on the restored code

## Verification

`scripts/verify.sh haskell` passes locally end-to-end: cabal build (all targets), fourmolu check, hlint (no hints), full test suite (PASS).

## Suggested follow-up

The autoloop resolving merge conflicts unsupervised caused this (second incident — it has also swept unrelated uncommitted work into its commits). Consider requiring it to abort and flag conflicts instead of resolving them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)