### PR TITLE
style: fourmolu formatting + hlint fix for PR #152 code

### DIFF
--- a/haskell/app/Main.hs
+++ b/haskell/app/Main.hs
@@ -161,6 +161,7 @@ import Trader.Binance (
     BinanceOpenOrder (..),
     BinanceOrderMode (..),
     BinanceTrade (..),
+    BookTickerQuote (..),
     FuturesAlgoOpenOrder (..),
     FuturesPositionRisk (..),
     Kline (..),
@@ -173,15 +174,13 @@ import Trader.Binance (
     binanceMarketDataCacheStats,
     binanceProxyHealth,
     binanceTestnetBaseUrl,
-    BookTickerQuote (..),
     cancelFuturesAlgoOrderByClientId,
     cancelFuturesOpenOrdersByClientPrefix,
     cancelFuturesOrderByClientId,
-    fetchBookTickerQuote,
-    placeFuturesPostOnlyLimitOrder,
     closeListenKey,
     createListenKey,
     fetchAccountTrades,
+    fetchBookTickerQuote,
     fetchCloses,
     fetchFreeBalance,
     fetchFuturesAccountUid,
@@ -202,6 +201,7 @@ import Trader.Binance (
     newBinanceEnv,
     placeFuturesAlgoTriggerMarketOrder,
     placeFuturesMarketOrderWithPositionSide,
+    placeFuturesPostOnlyLimitOrder,
     placeFuturesTriggerMarketOrder,
     placeMarketOrder,
     quantizeDown,
@@ -22319,7 +22319,7 @@ placeOrderForSignalEx args sym sig env mClientOrderIdOverride enableProtectionOr
                                                                 -- A fill can land between cancel and this fetch; the
                                                                 -- final read captures it.
                                                                 finalOrErr <- try (fetchOrderByClientId env sym cid) :: IO (Either SomeException BL.ByteString)
-                                                                let mFinal = (either (const Nothing) decodeOrderInfo finalOrErr) <|> mInfo
+                                                                let mFinal = either (const Nothing) decodeOrderInfo finalOrErr <|> mInfo
                                                                 if filledOf mFinal > 0
                                                                     then resultFrom mFinal "Maker order partially filled at timeout; remainder canceled."
                                                                     else fallback "timed out unfilled"

--- a/haskell/app/Trader/Binance.hs
+++ b/haskell/app/Trader/Binance.hs
@@ -917,8 +917,9 @@ fetchTickerPrice env symbol = do
         Left e -> throwIO (userError ("Failed to decode ticker price: " ++ e))
         Right (TickerPrice p) -> pure p
 
--- | Best bid/ask from the order book ticker; maker (post-only) entries price
--- off the touch rather than the last trade.
+{- | Best bid/ask from the order book ticker; maker (post-only) entries price
+off the touch rather than the last trade.
+-}
 data BookTickerQuote = BookTickerQuote
     { btqBid :: !Double
     , btqAsk :: !Double


### PR DESCRIPTION
Follow-up to #152 (auto-merged before the style pass landed): fourmolu formatting on the new Binance.hs/Main.hs code and one hlint redundant-bracket fix. No behavior change — `scripts/verify.sh haskell` (fourmolu check, hlint, build, tests) passes locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)