### PR TITLE
fix(optimizer): unstall combo discovery (OOM-safe LSTM gradients, board refresh, method-01 weights)

### DIFF
--- a/deploy/hetzner/trader.research.env.managed
+++ b/deploy/hetzner/trader.research.env.managed
@@ -20,3 +20,14 @@ TRADER_OPTIMIZER_MAX_POINTS=2000
 TRADER_OPTIMIZER_CROSS_EXCHANGE_COINBASE=true
 TRADER_OPTIMIZER_DISCOVERY_RECOVERY_TRIALS=12
 TRADER_OPTIMIZER_DISCOVERY_RECOVERY_TIMEOUT_SEC=600
+# Periodic leaderboard refresh: re-backtest top combos under the current cost
+# model so stale pre-cost-fix scores deflate honestly and fresh discoveries
+# can rank in. The board froze on 2026-03-25 because its rank-500 floor
+# (annualized ~5x, scored under the old optimistic cost model) is unreachable
+# for any honest candidate. 120 combos per 3h sweep walks the whole 500-combo
+# board in ~5 sweeps; refreshed combos re-rank (and sink) immediately.
+TRADER_TOP_COMBOS_BACKTEST_ENABLED=true
+TRADER_TOP_COMBOS_BACKTEST_TOP_N=120
+TRADER_TOP_COMBOS_BACKTEST_EVERY_SEC=10800
+# Allow refresh/validation of combos up to the discovery sampling cap.
+TRADER_API_MAX_HIDDEN_SIZE=64

--- a/haskell/app/Main.hs
+++ b/haskell/app/Main.hs
@@ -404,6 +404,7 @@ import Trader.TopCombosStore (
     ComboLiveStats (..),
     TopCombosMergeStats (..),
     TopCombosStore (..),
+    applyComboUpdatesKeepAllWithStats,
     applyComboUpdatesWithStats,
     blendedAnnualizedReturn,
     comboIdentityKey,
@@ -9975,9 +9976,15 @@ and families that hold up live gain it.
 -}
 autoOptimizerBaseMethodWeights :: [(String, String, Double)]
 autoOptimizerBaseMethodWeights =
+    -- Base mix favors LSTM-only ("01"): Kalman-only ("10") produced zero
+    -- directional trades across ~4,800 research-box trials (all
+    -- KALMAN_NEUTRAL, see 4b2dd3f1), while LSTM-only is the family that
+    -- actually trades. "10" keeps a small nonzero base so the live-gap
+    -- multiplier can re-balance toward it if its live record earns it
+    -- (a zero base stays zero forever).
     [ ("--method-weight-11", "11", 0.0)
-    , ("--method-weight-10", "10", 4.0)
-    , ("--method-weight-01", "01", 0.1)
+    , ("--method-weight-10", "10", 0.5)
+    , ("--method-weight-01", "01", 4.0)
     , ("--method-weight-edge-blend", "edge_blend", 0.0)
     , ("--method-weight-edge-pick", "edge_pick", 0.0)
     , ("--method-weight-regime-switch", "regime_switch", 0.0)
@@ -10631,6 +10638,19 @@ backtestTopCombosOnce topNRaw ctx = do
                                                                 Nothing -> do
                                                                     recordError "optimizer.combos.backtest_failed" "Backtest missing metrics." (Just sym) mInterval
                                                                     pure Nothing
+                                                                Just metricsVal
+                                                                    -- A zero-trade window is a verdict on the window,
+                                                                    -- not the combo (2026-06-10 invariant): do not
+                                                                    -- persist smoke metrics over the optimizer's
+                                                                    -- out-of-sample reading.
+                                                                    | comboMetricInt "tradeCount" metricsVal == Just 0 -> do
+                                                                        recordEvent
+                                                                            "optimizer.combos.backtest_no_verdict"
+                                                                            [ "symbol" .= sym
+                                                                            , "interval" .= mInterval
+                                                                            , "reason" .= ("zero-trade window" :: String)
+                                                                            ]
+                                                                        pure Nothing
                                                                 Just metricsVal -> do
                                                                     let mFinalEq = comboMetricDouble "finalEquity" metricsVal
                                                                         objective = fromMaybe "final-equity" (tcObjectiveLabel combo)
@@ -10682,7 +10702,11 @@ backtestTopCombosOnce topNRaw ctx = do
                                                 Right latestVal -> do
                                                     now <- getTimestampMs
                                                     let updateMap = HM.fromList updates
-                                                    case applyComboUpdatesWithStats now updateMap latestVal of
+                                                    -- Keep (deflated) rather than prune: a locally pruned combo
+                                                    -- resurrects with its stale score via the cross-instance
+                                                    -- union merge; a kept, freshly-stamped record wins those
+                                                    -- merges and drops off the capped board by rank instead.
+                                                    case applyComboUpdatesKeepAllWithStats now updateMap latestVal of
                                                         Left err -> do
                                                             recordError "optimizer.combos.backtest_failed" err Nothing Nothing
                                                             pure False

--- a/haskell/app/Trader/LSTM.hs
+++ b/haskell/app/Trader/LSTM.hs
@@ -20,6 +20,7 @@ module Trader.LSTM (
 import qualified Data.Bifunctor
 import Data.List (foldl')
 import qualified Data.Vector as V
+import qualified Data.Vector.Unboxed as VU
 import Numeric.AD (grad)
 import System.Random (mkStdGen, randomRs)
 
@@ -290,7 +291,7 @@ trainLoop cfg d hidden trainSet valSet initFlat =
                      in if shouldStop
                             then (bestFlat', reverse history')
                             else
-                                let g = grad (lossFromFlatWeightedDV d hidden trainSet) flat
+                                let g = gradWeightedPerSample d hidden trainSet flat
                                     g' =
                                         case clip of
                                             Nothing -> g
@@ -389,6 +390,36 @@ lossFromFlatDV d hidden dataset flat =
      in if nInt <= 0
             then 0
             else foldl' (\acc x -> acc + err x) 0 dataset / n
+
+{- | Gradient of 'lossFromFlatWeightedDV' computed sample-by-sample.
+
+Reverse-mode AD materializes a tape node for every arithmetic operation under
+the differentiated function. Differentiating the whole-dataset loss in one
+call (the old @grad (lossFromFlatWeightedDV ...)@) therefore held
+O(samples x lookback x hidden^2) boxed tape nodes live at once — gigabytes at
+research shapes (lookback 720, hidden 64), which is what OOM-killed LSTM
+optimizer trials. Differentiating per sample keeps the tape at one window and
+lets each one be collected before the next, with the identical result:
+@d/dp [ sum_i (w_i e_i^2) / sum w ] = sum_i d/dp (w_i e_i^2) / sum w@.
+The per-sample gradients are accumulated in the same left-to-right sample
+order the dataset fold used, into a strict unboxed vector so no thunk chains
+rebuild the leak.
+-}
+gradWeightedPerSample :: Int -> Int -> [(V.Vector Double, Double, Double)] -> [Double] -> [Double]
+gradWeightedPerSample d hidden dataset flat =
+    let nParams = length flat
+        sumW = foldl' (\acc (_, _, w) -> acc + w) 0 dataset :: Double
+        sampleLoss s fl =
+            let p = unflattenParamsD hidden d fl
+                (w, yTrue, wt) = s
+                yPred = forwardWindowDV d p (V.map realToFrac w)
+                e = yPred - realToFrac yTrue
+             in realToFrac wt * e * e
+        accum acc s = VU.zipWith (+) acc (VU.fromListN nParams (grad (sampleLoss s) flat))
+        total = foldl' accum (VU.replicate nParams 0) dataset
+     in if null dataset || sumW <= 0 || isNaN sumW || isInfinite sumW
+            then replicate nParams 0
+            else VU.toList (VU.map (/ sumW) total)
 
 {- | Weighted mean-squared error: @sum(w_i * e_i^2) / sum(w_i)@. With unit
 weights this is numerically identical to 'lossFromFlatDV' (multiplying by the

--- a/haskell/app/Trader/Optimizer/Optimize.hs
+++ b/haskell/app/Trader/Optimizer/Optimize.hs
@@ -2049,11 +2049,31 @@ buildCommand traderBin baseArgs params0 tuneRatio useSweepThreshold =
                 else cmd36j
      in cmd37 ++ ["--json"]
 
+{- | Heap cap passed to each spawned trial process (GHC RTS @-M@; the trader
+binaries are built with @-rtsopts@). A runaway trial then dies with a clean
+heap-overflow error recorded in its trial record, instead of growing until
+the host OOM killer reaps it (and stalls every other trial on the box).
+Override with TRADER_OPTIMIZER_TRIAL_HEAP_CAP; \"0\", \"off\" or \"none\"
+disables the cap.
+-}
+trialHeapCapRtsArgs :: IO [String]
+trialHeapCapRtsArgs = do
+    raw <- lookupEnv "TRADER_OPTIMIZER_TRIAL_HEAP_CAP"
+    let val =
+            case fmap trim raw of
+                Just s | not (null s) -> s
+                _ -> "12g"
+    pure $
+        if map toLower val `elem` ["0", "off", "none", "disabled"]
+            then []
+            else ["+RTS", "-M" ++ val, "-RTS"]
+
 runTrial :: FilePath -> [String] -> TrialParams -> Double -> Bool -> Double -> Bool -> IO TrialResult
 runTrial traderBin baseArgs params0 tuneRatio useSweepThreshold timeoutSec disableLstm = do
     let params = normalizeTrialParams params0
     let cmd = buildCommand traderBin baseArgs params tuneRatio useSweepThreshold
-        cmdArgs = drop 1 cmd
+    rtsCapArgs <- trialHeapCapRtsArgs
+    let cmdArgs = drop 1 cmd ++ rtsCapArgs
     env0 <- getEnvironment
     let env = if disableLstm then setEnv "TRADER_LSTM_WEIGHTS_DIR" "" env0 else env0
         procSpec =

--- a/haskell/app/Trader/TopCombosStore.hs
+++ b/haskell/app/Trader/TopCombosStore.hs
@@ -8,7 +8,9 @@ module Trader.TopCombosStore (
     TopCombosStore (..),
     applyComboUpdates,
     applyComboUpdatesWithStats,
+    applyComboUpdatesKeepAllWithStats,
     blendedAnnualizedReturn,
+    comboBacktestFreshnessMs,
     compactTopCombosPayloadForSync,
     comboFinalEquityValue,
     comboIdentityKey,
@@ -239,7 +241,14 @@ sanitizeTopCombosValue val =
                     let combosList = V.toList combos
                         (kept, changed) = foldl' apply ([], 0) combosList
                         apply (acc, count) comboVal =
-                            if not (comboEquityAboveOne comboVal) || not (comboOpenThresholdDeployable comboVal)
+                            -- A sub-1.0 combo carrying a refresh stamp is an honest
+                            -- re-backtest reading, not junk: it must survive into the
+                            -- merge so it can beat the stale, inflated copies peer
+                            -- instances still publish (see 'pickBestCombo') and then
+                            -- sink off the capped board by rank. Dropping it here
+                            -- would resurrect the stale copy on every union merge.
+                            if (not (comboEquityAboveOne comboVal) && not (comboCarriesRefreshStamp comboVal))
+                                || not (comboOpenThresholdDeployable comboVal)
                                 then (acc, count + 1)
                                 else
                                     let (comboVal', updated) = sanitizeComboValue comboVal
@@ -559,6 +568,28 @@ coerceInt64Value value =
             case value of
                 Aeson.String s -> readMaybe (trim (T.unpack s))
                 _ -> Nothing
+
+comboTopLevelInt64 :: String -> Aeson.Value -> Maybe Int64
+comboTopLevelInt64 key val =
+    case val of
+        Aeson.Object o -> KM.lookup (AK.fromString key) o >>= coerceInt64Value
+        _ -> Nothing
+
+-- | When this combo's backtest metrics were last refreshed in place.
+comboBacktestRefreshedAtMs :: Aeson.Value -> Maybe Int64
+comboBacktestRefreshedAtMs = comboTopLevelInt64 "backtestRefreshedAtMs"
+
+comboCarriesRefreshStamp :: Aeson.Value -> Bool
+comboCarriesRefreshStamp = isJust . comboBacktestRefreshedAtMs
+
+{- | How fresh this combo's backtest reading is: the in-place refresh stamp
+when present, else the discovery time. A freshly discovered duplicate is
+itself a fresh backtest of the same identity, so 'createdAtMs' is the right
+fallback when comparing against a refreshed record.
+-}
+comboBacktestFreshnessMs :: Aeson.Value -> Maybe Int64
+comboBacktestFreshnessMs val =
+    comboBacktestRefreshedAtMs val <|> comboTopLevelInt64 "createdAtMs" val
 
 recalculateComboPerformanceFromOperation ::
     Int64 ->
@@ -1129,7 +1160,20 @@ mergeTopCombosPayloadsWithStats maxItems now payloads =
             scoreVal = fromMaybe (negate (1 / 0))
             finalEqNew = fromMaybe 0 (comboFinalEquityValue newer)
             finalEqPrev = fromMaybe 0 (comboFinalEquityValue prev)
+            -- Once either duplicate carries an in-place refresh stamp, the
+            -- most recent backtest reading is authoritative — best-ever-score
+            -- semantics would let a stale replica's inflated record undo an
+            -- honest (deflating) refresh on every union merge. Unstamped
+            -- duplicates keep the historical best-ever behavior.
+            anyStamped = isJust (comboBacktestRefreshedAtMs newer) || isJust (comboBacktestRefreshedAtMs prev)
+            freshNew = comboBacktestFreshnessMs newer
+            freshPrev = comboBacktestFreshnessMs prev
             best
+                | anyStamped
+                , Just fn <- freshNew
+                , Just fp <- freshPrev
+                , fn /= fp =
+                    if fn > fp then newer else prev
                 | objNew == objPrev && (isJust scoreNew || isJust scorePrev) =
                     if scoreVal scoreNew > scoreVal scorePrev then newer else prev
                 | finalEqNew > finalEqPrev = newer
@@ -1146,8 +1190,8 @@ data ComboBacktestUpdate = ComboBacktestUpdate
     , cbuOperations :: !(Maybe Aeson.Value)
     }
 
-updateComboWithBacktest :: ComboBacktestUpdate -> Aeson.Value -> Aeson.Value
-updateComboWithBacktest update comboVal =
+updateComboWithBacktest :: Int64 -> ComboBacktestUpdate -> Aeson.Value -> Aeson.Value
+updateComboWithBacktest now update comboVal =
     case comboVal of
         Aeson.Object o ->
             -- Backtests know nothing about live trading: carry the prior
@@ -1170,7 +1214,12 @@ updateComboWithBacktest update comboVal =
                     case cbuOperations update of
                         Nothing -> o3
                         Just ops -> KM.insert (AK.fromString "operations") ops o3
-             in Aeson.Object o4
+                -- Stamp the refresh time so identity merges can prefer the most
+                -- recent backtest reading (see 'pickBestCombo'); without the
+                -- stamp a deflating refresh would lose every union merge to a
+                -- stale replica still carrying the old, higher score.
+                o5 = KM.insert (AK.fromString "backtestRefreshedAtMs") (toJSON now) o4
+             in Aeson.Object o5
         _ -> comboVal
 
 applyComboUpdates :: Int64 -> HM.HashMap BS.ByteString ComboBacktestUpdate -> Aeson.Value -> Either String (Aeson.Value, Int)
@@ -1184,7 +1233,7 @@ applyComboUpdates now updates val =
                         applyOne (acc, count) comboVal =
                             case comboIdentityKey comboVal >>= (`HM.lookup` updates) of
                                 Nothing -> (comboVal : acc, count)
-                                Just upd -> (updateComboWithBacktest upd comboVal : acc, count + 1)
+                                Just upd -> (updateComboWithBacktest now upd comboVal : acc, count + 1)
                         combosOut = Aeson.Array (V.fromList (reverse updatedCombos))
                         o' = KM.insert (AK.fromString "combos") combosOut (KM.insert (AK.fromString "generatedAtMs") (toJSON now) o)
                     Right (Aeson.Object o', updatedCount)
@@ -1208,7 +1257,20 @@ deleted 124 healthy combos in the 2026-06-10 launchd log. We detect the
 zero-trade case by reading the inbound update's metrics directly.
 -}
 applyComboUpdatesWithStats :: Int64 -> HM.HashMap BS.ByteString ComboBacktestUpdate -> Aeson.Value -> Either String (Aeson.Value, ComboBacktestApplyStats)
-applyComboUpdatesWithStats now updates val =
+applyComboUpdatesWithStats = applyComboUpdatesWithStatsPrune True
+
+{- | Like 'applyComboUpdatesWithStats' but never prunes: an unprofitable
+refresh keeps the combo with its deflated metrics (and refresh stamp). This
+is what the periodic leaderboard refresh wants — a locally pruned combo would
+be resurrected with its stale, inflated score by the next cross-instance
+union merge, whereas a kept, stamped record wins those merges and the combo
+then falls out of the capped board by rank, fleet-wide.
+-}
+applyComboUpdatesKeepAllWithStats :: Int64 -> HM.HashMap BS.ByteString ComboBacktestUpdate -> Aeson.Value -> Either String (Aeson.Value, ComboBacktestApplyStats)
+applyComboUpdatesKeepAllWithStats = applyComboUpdatesWithStatsPrune False
+
+applyComboUpdatesWithStatsPrune :: Bool -> Int64 -> HM.HashMap BS.ByteString ComboBacktestUpdate -> Aeson.Value -> Either String (Aeson.Value, ComboBacktestApplyStats)
+applyComboUpdatesWithStatsPrune pruneUnprofitable now updates val =
     case val of
         Aeson.Object o ->
             case KM.lookup (AK.fromString "combos") o of
@@ -1219,12 +1281,12 @@ applyComboUpdatesWithStats now updates val =
                             case comboIdentityKey comboVal >>= (`HM.lookup` updates) of
                                 Nothing -> (comboVal : acc, updCount, pruneCount, pKeys)
                                 Just upd ->
-                                    let updated = updateComboWithBacktest upd comboVal
+                                    let updated = updateComboWithBacktest now upd comboVal
                                         mEquity = comboFinalEquityValue updated
                                         mTrades = comboMetricInt "tradeCount" (cbuMetrics upd)
                                         -- A zero-trade update is not a verdict; keep the combo as-is.
                                         zeroTradeUpdate = mTrades == Just 0
-                                        keep = maybe True (> 1.0) mEquity || zeroTradeUpdate
+                                        keep = not pruneUnprofitable || maybe True (> 1.0) mEquity || zeroTradeUpdate
                                      in if keep
                                             then (updated : acc, updCount + 1, pruneCount, pKeys)
                                             else case comboIdentityKey comboVal of

--- a/haskell/test/TestMain.hs
+++ b/haskell/test/TestMain.hs
@@ -10,6 +10,7 @@ import Data.Aeson ((.=))
 import qualified Data.Aeson as Aeson
 import qualified Data.Aeson.Key as AK
 import qualified Data.Aeson.KeyMap as KM
+import qualified Data.Aeson.Types as AT
 import qualified Data.HashMap.Strict as HM
 import Data.Int (Int64)
 import Data.List (isInfixOf)
@@ -138,8 +139,10 @@ import Trader.TopCombosStore (
     ComboBacktestApplyStats (..),
     ComboBacktestUpdate (..),
     ComboLiveStats (..),
+    applyComboUpdatesKeepAllWithStats,
     applyComboUpdatesWithStats,
     blendedAnnualizedReturn,
+    comboBacktestFreshnessMs,
     comboIdentityKey,
     comboLiveQuarantined,
     comboLiveStats,
@@ -301,6 +304,11 @@ main = do
     testRecalculateMaintainsLiveStats
     testBacktestUpdatePreservesLiveStats
     testMergePreservesLiveStats
+    testMergeRefreshedComboBeatsStaleScore
+    testMergeNewerDiscoveryBeatsOlderRefresh
+    testMergeUnstampedDuplicatesKeepBestEver
+    testMergeSanitizeKeepsStampedSubOneRefresh
+    testKeepAllUpdateKeepsUnprofitableComboStamped
     testTradeOutcomeWeightsSemantics
     testWeightedFineTuneUnitWeightsEquivalence
     testWeightedFineTunePunishesLossRegion
@@ -2976,6 +2984,151 @@ testMergePreservesLiveStats = do
                 Nothing -> ioError (userError "merge dropped the live record")
                 Just s -> pure s
             assert "merge keeps the richest live record across duplicates" (clsOperationCount stats == 10)
+
+-- | Combo with controllable score / createdAtMs / refresh stamp for merge tests.
+freshnessComboForTest :: Double -> Maybe Int64 -> Maybe Int64 -> Aeson.Value
+freshnessComboForTest score mCreatedAt mRefreshedAt =
+    Aeson.object
+        ( [ "symbol" .= ("BTCUSDT" :: T.Text)
+          , "interval" .= ("15m" :: T.Text)
+          , "platform" .= ("binance" :: T.Text)
+          , "uuid" .= ("0badc0de-1234-5678-9abc-def012345678" :: T.Text)
+          , "finalEquity" .= (1.0 + score :: Double)
+          , "score" .= score
+          , "openThreshold" .= (0.005 :: Double)
+          , "closeThreshold" .= (0.010 :: Double)
+          , "objective" .= ("final-equity" :: T.Text)
+          , "params" .= Aeson.object ["method" .= ("blend" :: T.Text), "lookback" .= (48 :: Int)]
+          , "metrics" .= Aeson.object ["finalEquity" .= (1.0 + score :: Double), "tradeCount" .= (8 :: Int)]
+          ]
+            ++ maybe [] (\t -> ["createdAtMs" .= t]) mCreatedAt
+            ++ maybe [] (\t -> ["backtestRefreshedAtMs" .= t]) mRefreshedAt
+        )
+
+mergeWinnerScore :: [Aeson.Value] -> Maybe Double
+mergeWinnerScore combos =
+    let payload =
+            Aeson.object
+                [ "combos" .= combos
+                , "generatedAtMs" .= (9000 :: Int64)
+                , "source" .= ("test" :: T.Text)
+                ]
+        merged = mergeTopCombosPayloads 10 9500 [payload]
+     in case merged of
+            Aeson.Object o -> case KM.lookup "combos" o of
+                Just (Aeson.Array v) | not (V.null v) ->
+                    case V.head v of
+                        Aeson.Object c -> KM.lookup "score" c >>= AT.parseMaybe Aeson.parseJSON
+                        _ -> Nothing
+                _ -> Nothing
+            _ -> Nothing
+
+{- | Identity merges prefer the most recent backtest reading once a refresh
+stamp is involved: an honest (lower-scoring) in-place refresh must beat the
+stale, higher-scoring copy a lagging replica still publishes — otherwise the
+cross-instance union merge would undo every deflating refresh.
+-}
+testMergeRefreshedComboBeatsStaleScore :: IO ()
+testMergeRefreshedComboBeatsStaleScore = do
+    let stale = freshnessComboForTest 5.0 (Just 1000) Nothing
+        refreshed = freshnessComboForTest 0.1 (Just 1000) (Just 5000)
+    assert
+        "refreshed (deflated) combo wins the merge over the stale higher score"
+        (mergeWinnerScore [stale, refreshed] == Just 0.1)
+    assert
+        "winner is order-independent"
+        (mergeWinnerScore [refreshed, stale] == Just 0.1)
+
+{- | A re-discovered duplicate is itself a fresh backtest of the same
+identity: when its createdAtMs postdates the incumbent's refresh stamp, the
+new discovery wins even against a stamped record.
+-}
+testMergeNewerDiscoveryBeatsOlderRefresh :: IO ()
+testMergeNewerDiscoveryBeatsOlderRefresh = do
+    let refreshedOld = freshnessComboForTest 0.1 (Just 1000) (Just 5000)
+        rediscovered = freshnessComboForTest 0.4 (Just 8000) Nothing
+    assert
+        "newer discovery beats an older refresh stamp"
+        (mergeWinnerScore [refreshedOld, rediscovered] == Just 0.4)
+
+{- | Without any refresh stamp the historical best-ever-score semantics are
+unchanged, whatever the createdAtMs ordering says.
+-}
+testMergeUnstampedDuplicatesKeepBestEver :: IO ()
+testMergeUnstampedDuplicatesKeepBestEver = do
+    let older = freshnessComboForTest 5.0 (Just 1000) Nothing
+        newer = freshnessComboForTest 0.1 (Just 8000) Nothing
+    assert
+        "unstamped duplicates keep best-ever score"
+        (mergeWinnerScore [older, newer] == Just 5.0)
+
+{- | A refresh that deflates a combo BELOW 1.0 equity must still survive the
+merge's sanitize pass: dropping it there would hand the merge to the stale,
+inflated copy a peer instance still publishes, resurrecting it on every
+union merge. Unstamped sub-1.0 combos remain junk and are still dropped.
+-}
+testMergeSanitizeKeepsStampedSubOneRefresh :: IO ()
+testMergeSanitizeKeepsStampedSubOneRefresh = do
+    let stale = freshnessComboForTest 5.0 (Just 1000) Nothing
+        refreshedLoss = freshnessComboForTest (-0.15) (Just 1000) (Just 5000)
+    assert
+        "stamped sub-1.0 refresh beats the stale inflated copy in the merge"
+        (mergeWinnerScore [stale, refreshedLoss] == Just (-0.15))
+    assert
+        "stamped sub-1.0 winner is order-independent"
+        (mergeWinnerScore [refreshedLoss, stale] == Just (-0.15))
+    let unstampedLoss = freshnessComboForTest (-0.15) (Just 1000) Nothing
+    assert
+        "unstamped sub-1.0 combo is still sanitized away"
+        (mergeWinnerScore [unstampedLoss] == Nothing)
+
+{- | The periodic leaderboard refresh keeps unprofitable combos (deflated and
+stamped) instead of pruning them: a pruned record would resurrect with its
+stale score via the union merge, while a kept stamped record wins merges and
+sinks out of the capped board by rank.
+-}
+testKeepAllUpdateKeepsUnprofitableComboStamped :: IO ()
+testKeepAllUpdateKeepsUnprofitableComboStamped = do
+    let combosJson =
+            Aeson.object ["combos" .= [freshnessComboForTest 5.0 (Just 1000) Nothing]]
+        firstCombo = case combosJson of
+            Aeson.Object o -> case KM.lookup "combos" o of
+                Just (Aeson.Array v) | not (V.null v) -> Just (V.head v)
+                _ -> Nothing
+            _ -> Nothing
+        key = case firstCombo >>= comboIdentityKey of
+            Just k -> k
+            Nothing -> error "test setup: combo identity key resolution failed"
+        lossUpdate =
+            ComboBacktestUpdate
+                { cbuMetrics = Aeson.object ["finalEquity" .= (0.85 :: Double), "tradeCount" .= (12 :: Int)]
+                , cbuFinalEquity = Just 0.85
+                , cbuScore = Just (-0.15)
+                , cbuOperations = Nothing
+                }
+    case applyComboUpdatesKeepAllWithStats 7777 (HM.singleton key lossUpdate) combosJson of
+        Left err -> ioError (userError ("applyComboUpdatesKeepAllWithStats failed unexpectedly: " ++ err))
+        Right (updatedVal, stats) -> do
+            assert
+                "keep-all apply updates without pruning"
+                (cbasUpdatedCount stats == 1 && cbasPrunedCount stats == 0 && null (cbasPrunedKeys stats))
+            let mUpdated = case updatedVal of
+                    Aeson.Object o -> case KM.lookup "combos" o of
+                        Just (Aeson.Array v) | not (V.null v) -> Just (V.head v)
+                        _ -> Nothing
+                    _ -> Nothing
+            case mUpdated of
+                Nothing -> ioError (userError "keep-all apply dropped the combo")
+                Just updated -> do
+                    let mEq = case updated of
+                            Aeson.Object c -> KM.lookup "finalEquity" c >>= AT.parseMaybe Aeson.parseJSON
+                            _ -> Nothing
+                    assert
+                        "unprofitable refresh persists deflated metrics"
+                        (mEq == Just (0.85 :: Double))
+                    assert
+                        "refresh stamps backtestRefreshedAtMs"
+                        (comboBacktestFreshnessMs updated == Just 7777)
 
 mkOutcomeTestTrade :: Int -> Int -> Double -> Trade
 mkOutcomeTestTrade entryIdx exitIdx ret =

--- a/haskell/test/TestMain.hs
+++ b/haskell/test/TestMain.hs
@@ -3080,7 +3080,7 @@ testMergeSanitizeKeepsStampedSubOneRefresh = do
     let unstampedLoss = freshnessComboForTest (-0.15) (Just 1000) Nothing
     assert
         "unstamped sub-1.0 combo is still sanitized away"
-        (mergeWinnerScore [unstampedLoss] == Nothing)
+        (isNothing (mergeWinnerScore [unstampedLoss]))
 
 {- | The periodic leaderboard refresh keeps unprofitable combos (deflated and
 stamped) instead of pruning them: a pruned record would resurrect with its


### PR DESCRIPTION
## Why

No new combo has ranked into the top-combos board since **2026-03-25** (combo #77, LINKUSDT 1h). Verified live on the research box: the 500-combo board's newest `createdAtMs` is 2026-03-25 17:38 UTC.

Three independent causes, all fixed here:

### 1. Big-LSTM trials were OOM-killed
Reverse-mode AD over the whole-dataset weighted loss holds O(samples × lookback × hidden²) tape nodes live at once. Confirmed on the research box kernel log (Jun 02): `trader-hs` killed at 15 GB RSS / ~1 TB total-vm. So the wider sampling caps shipped earlier (`epochs≤16 / hidden≤64`) made trials die instead of discover.

- `trainLoop` now computes the gradient per sample — mathematically identical (`sumW` is constant w.r.t. params), tape stays one window deep.
- Each spawned trial gets a GHC RTS heap cap (`-M12g` default, `TRADER_OPTIMIZER_TRIAL_HEAP_CAP` to override/disable) so a runaway trial records a clean heap-overflow failure instead of stalling the whole box.

### 2. The board froze at an unreachable floor
The rank-500 floor was scored under the old optimistic cost model — unreachable for any honest candidate. This enables the periodic leaderboard refresh on the research box (120 combos / 3h ⇒ full board in ~5 sweeps; currently `TRADER_TOP_COMBOS_BACKTEST_ENABLED=false` on the box). Refresh correctness:

- Refreshes stamp `backtestRefreshedAtMs`; identity merges prefer the freshest stamped reading over best-ever score, so a deflating refresh isn't resurrected by a stale replica on every cross-instance union merge.
- Unprofitable refreshes are **kept** (deflated + stamped), not pruned — a pruned record would resurrect via the union merge; a kept one wins merges and sinks off the capped board by rank, fleet-wide.
- Stamped sub-1.0 combos survive the sanitize pass (unstamped junk is still dropped); zero-trade windows are no-verdict (2026-06-10 invariant).

### 3. Discovery method weights had regressed to Kalman-heavy
4b2dd3f1 switched discovery to method-01-heavy (Kalman-only produced **0 directional trades across ~4,800 trials**, all `KALMAN_NEUTRAL`), but the automated merge resolution dropped that hunk when 479e9a43 rebuilt the weights table with the old `10=4.0 / 01=0.1` values. Restored to `01=4.0 / 10=0.5` (small nonzero base so the live-gap multiplier can re-balance "10" if it ever earns it).

## Testing

- `cabal build` + full `trader-tests` suite green, including 5 new tests covering merge freshness semantics, sanitize-keeps-stamped-refresh, and keep-all apply.
- fourmolu `--mode check` and hlint clean on touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)