### PR TITLE
Formalize edge campaign research guarantees

### DIFF
--- a/docs/formal-verification-audit-2026-07-12.md
+++ b/docs/formal-verification-audit-2026-07-12.md
@@ -31,6 +31,7 @@ This is bounded/executable formal verification, not a claim of unbounded mathema
 21. Credential tuples were joined with a separator, so distinct credentials containing `:` could derive the same tenant. Backend, browser, and AWS now trim the same ASCII boundary whitespace, preserve legacy keys for separator-free tuples including Unicode credentials, and use a domain-separated, UTF-8 byte-length-framed `platform:v2` identity only for separator-bearing tuples; collision and Unicode-boundary vectors agree across all three runtimes.
 22. Successful bot lifecycle responses relied on compile-time TypeScript shapes. Bot start/status/stop now decode the safety envelope before UI mutation, require non-empty aligned core running series, bind applicable response tenant/symbol identities to the request, and reject malformed snapshot or multi-bot evidence without retrying a successful mutation.
 23. Risk IDs and lifecycle state drifted between duplicate Markdown rows and a partial Haskell representation. `formal/risk-register.json` is now canonical, with automation enforcing unique ordered IDs and exact severity/status parity in both projections.
+24. The research edge campaign was covered only by a broad script glob, leaving its specific nested-validation, formal DSR, CSCV/PBO, derivatives-ablation, and one-shot final-holdout guarantees implicit. `A-RESEARCH` now names those obligations and links direct regression evidence.
 
 ## Remaining conformance gaps
 
@@ -42,7 +43,7 @@ The registry specifies these behaviors, but current evidence is incomplete and m
 - Web orchestration, SSE EOF/reconnect behavior, and multi-chunk state-sync partial failure lack a full state-machine test harness.
 - Client runtime API tokens are public credentials by construction and must never be treated as server secrets.
 - Venue signing/filter/pagination behavior, S3/state-sync atomicity, outbox delivery, migrations, and deployment rollback have static/integration witnesses rather than model-checked proofs.
-- Research and optimizer no-lookahead contracts need generated prefix/walk-forward properties across every preprocessing path.
+- Optimizer no-lookahead contracts and non-edge research preprocessing paths need generated prefix/walk-forward properties across every preprocessing path.
 - Hetzner exact remote projection, watchdog process identity, radio SSRF restrictions, AWS temporary-secret cleanup, and transactional state sync need additional implementation hardening.
 
 The strongest next step is a small pure core library with QuickCheck/Hedgehog properties and SBV/Z3 proofs for time arithmetic, gates, execution, and risk transitions, followed by a state-machine refinement test shared by live and backtest paths.

--- a/formal/specifications.json
+++ b/formal/specifications.json
@@ -502,16 +502,34 @@
     {
       "id": "A-RESEARCH",
       "title": "Research acquisition, point-in-time cache, walk-forward harness, and statistical analysis",
-      "features": ["research data feed", "append-only cache", "walk-forward harness", "cost model", "bootstrap", "deflated Sharpe", "regime experiment", "cross-sectional example"],
+      "features": ["research data feed", "append-only cache", "walk-forward harness", "nested rolling-origin validation", "edge campaign", "derivatives-feature ablations", "cost model", "bootstrap", "deflated Sharpe", "CSCV PBO", "one-shot final holdout registry", "regime experiment", "cross-sectional example"],
       "criticality": "correctness",
       "implementation": ["scripts/research/**", "scripts/fetch-data-pipeline.sh"],
       "uses": ["G-CAUSAL", "G-NO-LOOKAHEAD", "G-DETERMINISTIC", "G-IDEMPOTENT"],
       "dependsOn": ["H-MARKET-DATA", "H-METRICS"],
-      "requires": [{ "id": "A-RESEARCH-R1", "statement": "Every observation has event/publication time, preprocessing is fit only on each training prefix, and cache overlap has an explicit field-level merge policy." }],
-      "ensures": [{ "id": "A-RESEARCH-E1", "statement": "Walk-forward results use disjoint chronological evaluation folds; overlapping refresh cannot replace known historical values with missing data; seed/config/data revision are recorded." }],
-      "invariants": [{ "id": "A-RESEARCH-I1", "statement": "A future row cannot change earlier standardized features or signals; transaction costs are applied only after a causal decision." }],
-      "failures": [{ "id": "A-RESEARCH-F1", "statement": "Missing publication metadata, incomplete overlap, or failed acquisition preserves prior cache and marks the experiment incomplete." }],
-      "evidence": [{ "level": "regression", "path": "haskell/scripts/test_review_bot_day.py", "contains": "unittest" }]
+      "requires": [
+        { "id": "A-RESEARCH-R1", "statement": "Every observation has event/publication time, preprocessing is fit only on each training prefix, and cache overlap has an explicit field-level merge policy." },
+        { "id": "A-RESEARCH-R2", "statement": "Pre-registered edge campaigns enumerate the complete trial grid, align all symbol/feature panels to an exact chronological bar grid, and seal the final holdout unless all promotion gates pass." }
+      ],
+      "ensures": [
+        { "id": "A-RESEARCH-E1", "statement": "Walk-forward results use disjoint chronological evaluation folds; overlapping refresh cannot replace known historical values with missing data; seed/config/data revision are recorded." },
+        { "id": "A-RESEARCH-E2", "statement": "Nested selection fits only embargoed training prefixes, evaluates the frozen selected candidate once on each untouched outer fold, and records complete trial-return matrices for formal DSR and CSCV/PBO diagnostics." }
+      ],
+      "invariants": [
+        { "id": "A-RESEARCH-I1", "statement": "A future row cannot change earlier standardized features or signals; transaction costs are applied only after a causal decision." },
+        { "id": "A-RESEARCH-I2", "statement": "Formal multiple-testing diagnostics operate on complete finite aligned return matrices; final-holdout openings are one-shot across overlapping symbol/time windows and completed entries reference atomically written evidence." }
+      ],
+      "failures": [
+        { "id": "A-RESEARCH-F1", "statement": "Missing publication metadata, incomplete overlap, or failed acquisition preserves prior cache and marks the experiment incomplete." },
+        { "id": "A-RESEARCH-F2", "statement": "Sparse, incomplete, non-finite, misaligned, or ambiguous edge-campaign evidence fails closed before promotion or final-holdout consumption." }
+      ],
+      "evidence": [
+        { "level": "regression", "path": "haskell/scripts/test_review_bot_day.py", "contains": "unittest" },
+        { "level": "regression", "path": "test/research-edge-campaign.test.mjs", "contains": "edge campaign is causal, complete, and cost monotone" },
+        { "level": "regression", "path": "test/research-statistics.test.mjs", "contains": "formal DSR matches a fixed cross-trial benchmark" },
+        { "level": "regression", "path": "test/research-statistics.test.mjs", "contains": "CSCV PBO separates a stable winner" },
+        { "level": "regression", "path": "test/research-validation.test.mjs", "contains": "nested validation selects on inner rows" }
+      ]
     },
     {
       "id": "A-CALIBRATION",


### PR DESCRIPTION
## Summary
- Add explicit A-RESEARCH clauses for the edge campaign, derivatives ablations, formal DSR, CSCV/PBO, nested validation, and one-shot final holdout registry
- Link the formal registry directly to the new research regression tests
- Update the formal verification audit to record this repaired specification gap

## Verification
- node scripts/verify-formal-specs.mjs
- bash scripts/verify.sh automation
- git diff --check