### PR TITLE
research: record rate-limit circuit observation

### DIFF
--- a/research-notes/2026-09-05-binance-public-rate-limit-circuit-v1.md
+++ b/research-notes/2026-09-05-binance-public-rate-limit-circuit-v1.md
@@ -65,6 +65,25 @@ scheduler attempts, and explicit remaining-symbol skips. The existing
 historical downloader tests still pass unchanged. The previously frozen
 10-symbol receipt also reconstructs successfully after this change.
 
+The first installed scheduler run with the circuit implementation, from
+`2026-09-05T06:10:22.106590Z` through `2026-09-05T06:10:43.867674Z`, provided
+direct operational confirmation. It ran from clean commit
+`fb29dacbe65acff0a90d01ac3c8b41b20af2ef5b`, completed BTC, received HTTP 429
+on ETH, marked the remaining eight symbols
+`provider_rate_limit_circuit_open`, and stopped `partial_failure` in 21.761
+seconds. The circuit paths at that commit were unchanged by the conflict-free
+rebase to merged PR #218 head
+`b57f5c13f32f51a60d8f2b3a3f0e77b0a1bae787`.
+
+The mutable status file was observed at 7,743 bytes with SHA-256
+`6901b51ecb80fb087637427f577e5b93f17f85569f4393806af2aec8806ed552`
+before its next scheduled replacement. A sanitized metadata-only record is
+committed as
+[`binance-rate-limit-circuit-2026-09-05T061022Z.json`](market-prediction-2026-09-04/receipts/binance-rate-limit-circuit-2026-09-05T061022Z.json).
+The raw mutable status remains outside Git. This observation confirms circuit
+operation only; it is neither a successful artifact receipt nor permission to
+use partial data in an experiment.
+
 The process-local limiter cannot coordinate unrelated programs or machines on
 the same egress IP. An hourly run may still fail before receiving a usable
 weight header, and any resulting acquisition gap is irrecoverable for

--- a/research-notes/market-prediction-2026-09-04/receipts/binance-rate-limit-circuit-2026-09-05T061022Z.json
+++ b/research-notes/market-prediction-2026-09-04/receipts/binance-rate-limit-circuit-2026-09-05T061022Z.json
@@ -1,0 +1,85 @@
+{
+  "schemaVersion": 1,
+  "receiptId": "binance_rate_limit_circuit_2026-09-05T061022Z",
+  "receiptType": "metadata_only_operational_circuit_receipt",
+  "collection": {
+    "statusSchemaVersion": 3,
+    "interval": "1h",
+    "startedAt": "2026-09-05T06:10:22.106590Z",
+    "finishedAt": "2026-09-05T06:10:43.867674Z",
+    "durationSeconds": 21.761,
+    "codeCommit": "fb29dacbe65acff0a90d01ac3c8b41b20af2ef5b",
+    "mergedPullRequest": 218,
+    "mergedHeadCommit": "b57f5c13f32f51a60d8f2b3a3f0e77b0a1bae787",
+    "mergeCommit": "272d91c5bf32110ac0154931ec8f18cc1ab147d3",
+    "state": "partial_failure",
+    "provenanceIssues": [],
+    "provenanceTrackedClean": true
+  },
+  "source": {
+    "provider": "Binance USD-M Futures",
+    "access": "public_read_only",
+    "licenseManifest": "research-notes/market-prediction-2026-09-04/data-source-license-manifest.json"
+  },
+  "status": {
+    "logicalPath": ".collector/last-run.json",
+    "sha256": "6901b51ecb80fb087637427f577e5b93f17f85569f4393806af2aec8806ed552",
+    "bytes": 7743,
+    "retention": "Mutable operational status observed and hash-bound before its next scheduled replacement; raw status remains outside Git."
+  },
+  "universe": {
+    "symbols": [
+      "BTCUSDT",
+      "ETHUSDT",
+      "SOLUSDT",
+      "BNBUSDT",
+      "XRPUSDT",
+      "DOGEUSDT",
+      "ADAUSDT",
+      "AVAXUSDT",
+      "LINKUSDT",
+      "LTCUSDT"
+    ],
+    "stableOrder": "exact_fixed_collector_order"
+  },
+  "circuitObservation": {
+    "successfulBeforeThrottle": ["BTCUSDT"],
+    "throttleSymbol": "ETHUSDT",
+    "throttleStatus": "error",
+    "failureKind": "provider_rate_limit",
+    "httpStatus": 429,
+    "bannedUntilMs": null,
+    "retryAfterSeconds": null,
+    "remainingSymbols": [
+      "SOLUSDT",
+      "BNBUSDT",
+      "XRPUSDT",
+      "DOGEUSDT",
+      "ADAUSDT",
+      "AVAXUSDT",
+      "LINKUSDT",
+      "LTCUSDT"
+    ],
+    "remainingStatus": "skipped",
+    "remainingFailureKind": "provider_rate_limit_circuit_open",
+    "providerErrorMessageRetained": false,
+    "providerReturnedIpRetained": false,
+    "result": "circuit_observed"
+  },
+  "evidenceBoundary": {
+    "rawStatusCommitted": false,
+    "artifactAdmission": false,
+    "outcomeAdmission": "acquisition_metadata_only",
+    "returnsComputed": false,
+    "ranksComputed": false,
+    "weightsComputed": false,
+    "pnlComputed": false,
+    "riskMetricsComputed": false,
+    "forecastMetricsComputed": false,
+    "economicMetricsComputed": false,
+    "holdoutsOpened": 0,
+    "ordersPlaced": 0,
+    "modelInputsChanged": false,
+    "liveAuthorizationChanged": false
+  }
+}

--- a/test/market-prediction-research.test.mjs
+++ b/test/market-prediction-research.test.mjs
@@ -13,6 +13,11 @@ const derivativesReceiptUrl = new URL(
   import.meta.url,
 );
 
+const rateLimitCircuitReceiptUrl = new URL(
+  "../research-notes/market-prediction-2026-09-04/receipts/binance-rate-limit-circuit-2026-09-05T061022Z.json",
+  import.meta.url,
+);
+
 const requiredRegistrationKeys = [
   "ablations",
   "academicOrigin",
@@ -229,6 +234,70 @@ test("derivatives collection receipt binds metadata without opening outcomes", a
   assert.equal(receipt.verification.result, "verified_in_place_and_relocated");
   assert.deepEqual(receipt.outcomeBoundary, {
     admission: "acquisition_metadata_only",
+    returnsComputed: false,
+    ranksComputed: false,
+    weightsComputed: false,
+    pnlComputed: false,
+    riskMetricsComputed: false,
+    forecastMetricsComputed: false,
+    economicMetricsComputed: false,
+    holdoutsOpened: 0,
+    ordersPlaced: 0,
+    modelInputsChanged: false,
+    liveAuthorizationChanged: false,
+  });
+});
+
+test("rate-limit circuit receipt preserves sanitized operational evidence only", async () => {
+  const receiptText = await readFile(rateLimitCircuitReceiptUrl, "utf8");
+  const receipt = await readJson(rateLimitCircuitReceiptUrl);
+  const symbols = [
+    "BTCUSDT",
+    "ETHUSDT",
+    "SOLUSDT",
+    "BNBUSDT",
+    "XRPUSDT",
+    "DOGEUSDT",
+    "ADAUSDT",
+    "AVAXUSDT",
+    "LINKUSDT",
+    "LTCUSDT",
+  ];
+
+  assert.equal(receipt.schemaVersion, 1);
+  assert.equal(receipt.receiptType, "metadata_only_operational_circuit_receipt");
+  assert.equal(receipt.collection.statusSchemaVersion, 3);
+  assert.equal(receipt.collection.state, "partial_failure");
+  assert.equal(receipt.collection.provenanceTrackedClean, true);
+  assert.deepEqual(receipt.collection.provenanceIssues, []);
+  assert.ok(Date.parse(receipt.collection.startedAt) < Date.parse(receipt.collection.finishedAt));
+  assert.equal(receipt.collection.durationSeconds, 21.761);
+  for (const field of ["codeCommit", "mergedHeadCommit", "mergeCommit"]) {
+    assert.match(receipt.collection[field], /^[0-9a-f]{40}$/);
+  }
+  assert.equal(receipt.collection.mergedPullRequest, 218);
+  assert.equal(receipt.source.access, "public_read_only");
+  assert.match(receipt.status.sha256, /^[0-9a-f]{64}$/);
+  assert.equal(receipt.status.bytes, 7743);
+  assert.deepEqual(receipt.universe.symbols, symbols);
+  assert.deepEqual(receipt.circuitObservation.successfulBeforeThrottle, ["BTCUSDT"]);
+  assert.equal(receipt.circuitObservation.throttleSymbol, "ETHUSDT");
+  assert.equal(receipt.circuitObservation.failureKind, "provider_rate_limit");
+  assert.equal(receipt.circuitObservation.httpStatus, 429);
+  assert.equal(receipt.circuitObservation.bannedUntilMs, null);
+  assert.equal(receipt.circuitObservation.retryAfterSeconds, null);
+  assert.deepEqual(receipt.circuitObservation.remainingSymbols, symbols.slice(2));
+  assert.equal(receipt.circuitObservation.remainingStatus, "skipped");
+  assert.equal(receipt.circuitObservation.remainingFailureKind, "provider_rate_limit_circuit_open");
+  assert.equal(receipt.circuitObservation.providerErrorMessageRetained, false);
+  assert.equal(receipt.circuitObservation.providerReturnedIpRetained, false);
+  assert.equal(receipt.circuitObservation.result, "circuit_observed");
+  assert.doesNotMatch(receiptText, /\b(?:\d{1,3}\.){3}\d{1,3}\b/);
+  assert.doesNotMatch(receiptText, /"(?:errorMessage|rawError|providerMessage)"/);
+  assert.deepEqual(receipt.evidenceBoundary, {
+    rawStatusCommitted: false,
+    artifactAdmission: false,
+    outcomeAdmission: "acquisition_metadata_only",
     returnsComputed: false,
     ranksComputed: false,
     weightsComputed: false,


### PR DESCRIPTION
## Research summary

- Preserve the first installed scheduler observation of the Binance provider-rate-limit circuit before the mutable status file is replaced.
- Commit only a sanitized metadata receipt: exact status hash/size, causal symbol order, clean-code provenance, circuit disposition, and explicit evidence boundaries.
- Add a regression test that fixes the receipt schema and rejects IPv4 literals or raw-provider-message fields.

## Operational evidence

- Run: `2026-09-05T06:10:22.106590Z` through `2026-09-05T06:10:43.867674Z` (21.761 seconds).
- Clean observed code commit: `fb29dacbe65acff0a90d01ac3c8b41b20af2ef5b`.
- BTC completed; ETH returned HTTP 429; SOL, BNB, XRP, DOGE, ADA, AVAX, LINK, and LTC were marked `provider_rate_limit_circuit_open` and skipped.
- Terminal state: `partial_failure`.
- Mutable status evidence: 7,743 bytes, SHA-256 `6901b51ecb80fb087637427f577e5b93f17f85569f4393806af2aec8806ed552`.
- The circuit implementation/test paths are byte-identical between the observed clean commit and merged PR #218 head `b57f5c13f32f51a60d8f2b3a3f0e77b0a1bae787`.

## Evidence boundary and decision

This confirms the run-level circuit operated after installation. It does not prove uninterrupted acquisition, provider-quota ownership, or predictive efficacy. The raw mutable status and market-data artifacts remain outside Git.

No return, rank, weight, PnL, risk metric, forecast metric, economic metric, model fit, holdout, position, order, credential, or live-authorization state was read or changed. The partial run is not artifact-admissible. Recommendation remains: continue research; no candidate passed the promotion gates.

## Files changed

- `research-notes/market-prediction-2026-09-04/receipts/binance-rate-limit-circuit-2026-09-05T061022Z.json`
- `research-notes/2026-09-05-binance-public-rate-limit-circuit-v1.md`
- `test/market-prediction-research.test.mjs`

## Verification

- Receipt JSON parsed with `jq`; the observed and merged circuit paths had an empty `git diff`.
- `node --test test/market-prediction-research.test.mjs` — passed (7/7).
- `bash scripts/verify.sh automation` — passed (154/154 root tests).
- `bash scripts/verify.sh full` — passed (Haskell build/format/lint/smoke/tests; web typecheck, 241 tests, and production build; formal/deploy validation; 154 root tests).

Live trading remains disabled and unchanged.
