### PR TITLE
build(deps-dev): bump @types/react-dom to 19.2.7

### DIFF
--- a/haskell/web/package-lock.json
+++ b/haskell/web/package-lock.json
@@ -13,7 +13,7 @@
       },
       "devDependencies": {
         "@types/react": "^19.2.18",
-        "@types/react-dom": "^19.2.4",
+        "@types/react-dom": "^19.2.5",
         "@vitejs/plugin-react": "^6.1.1",
         "esbuild": "^0.28.2",
         "typescript": "^7.0.2",
@@ -766,9 +766,9 @@
       }
     },
     "node_modules/@types/react-dom": {
-      "version": "19.2.4",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.4.tgz",
-      "integrity": "sha512-Bsc+QHgp+P/F02XDzNCY9jnZNCUuLki36KT7VKrTXXLdHf+vHMNZnW1rVu5DNW/rCK+fya3DATySbLM4yhtKUw==",
+      "version": "19.2.5",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.5.tgz",
+      "integrity": "sha512-fMPwH9v7r/pp43yUd2/Mbiex5KouJwwR3dzHkhLREUC6764VyDsqxhAxv6OFEYR1RhjOyD1naqba8ECDBe7ZQg==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {

--- a/haskell/web/package-lock.json
+++ b/haskell/web/package-lock.json
@@ -13,7 +13,7 @@
       },
       "devDependencies": {
         "@types/react": "^19.2.18",
-        "@types/react-dom": "^19.2.5",
+        "@types/react-dom": "^19.2.7",
         "@vitejs/plugin-react": "^6.1.1",
         "esbuild": "^0.28.2",
         "typescript": "^7.0.2",
@@ -766,9 +766,9 @@
       }
     },
     "node_modules/@types/react-dom": {
-      "version": "19.2.5",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.5.tgz",
-      "integrity": "sha512-fMPwH9v7r/pp43yUd2/Mbiex5KouJwwR3dzHkhLREUC6764VyDsqxhAxv6OFEYR1RhjOyD1naqba8ECDBe7ZQg==",
+      "version": "19.2.7",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.7.tgz",
+      "integrity": "sha512-I8bPpDLcHBv1qiIiXDCy71Rt8eQDKJP0sMSWJphDdAcdqiJ1sGpZamavoEIRZmYzjia9LuEb2HlYdDpmoENpvQ==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {

--- a/haskell/web/package.json
+++ b/haskell/web/package.json
@@ -16,7 +16,7 @@
   },
   "devDependencies": {
     "@types/react": "^19.2.18",
-    "@types/react-dom": "^19.2.5",
+    "@types/react-dom": "^19.2.7",
     "@vitejs/plugin-react": "^6.1.1",
     "esbuild": "^0.28.2",
     "typescript": "^7.0.2",

--- a/haskell/web/package.json
+++ b/haskell/web/package.json
@@ -16,7 +16,7 @@
   },
   "devDependencies": {
     "@types/react": "^19.2.18",
-    "@types/react-dom": "^19.2.4",
+    "@types/react-dom": "^19.2.5",
     "@vitejs/plugin-react": "^6.1.1",
     "esbuild": "^0.28.2",
     "typescript": "^7.0.2",


### PR DESCRIPTION
## Summary

- replace stale conflicting Dependabot PR #206 on top of current main
- bump @types/react-dom from 19.2.4 to the current compatible release, 19.2.7
- preserve the already merged @vitejs/plugin-react 6.1.1 lockfile state

## Verification

- npm view @types/react-dom version — 19.2.7
- npm --workspaces=false --prefix haskell/web ci — PASS, 0 vulnerabilities
- bash scripts/verify.sh full — PASS on the final 19.2.7 state
  - Haskell suite PASS
  - web 241/241 and production build PASS
  - deployment and formal validation PASS
  - automation 154/154 PASS

Development dependency only; no runtime, trading, live authorization, or deployment behavior change.

Supersedes #206.